### PR TITLE
Remove hardcode.

### DIFF
--- a/EvolvAppExample/EvolvAppExample/ViewController.swift
+++ b/EvolvAppExample/EvolvAppExample/ViewController.swift
@@ -10,24 +10,21 @@ import Combine
 import EvolvSwiftSDK
 
 class ViewController: UIViewController {
-    
-    var cancellable: AnyCancellable?
+    var evolvClient: EvolvClient?
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view
         
-        let url = HttpConfig.configurationURL(domain: HttpConfig.stagingDomain)
-        cancellable = EvolvAPI.fetchData(for: url)
-            .catch {(error: HTTPError) -> Just<String?> in
-                print("\(error.localizedDescription)")
-                return Just(nil)
-            }
-            .sink {
-                if let body = $0 {
-                    print(body)
-                }
-            }
+        // Initialise options for the EvolvClient.
+        // Provide your credentials for the Evolv API.
+        let options = EvolvClientOptions(evolvDomain: "participants-stg.evolv.ai", participantID: "80658403_1629111253538", environmentId: "4a64e0b2ab")
+        
+        // Initialise and populate EvolvClient with desired options.
+        // Store this object to work with it later.
+        // After the completionHandler is fired and the error is nil,
+        // the EvolvClient is ready to be worked with.
+        evolvClient = EvolvClientImpl(options: options, completionHandler: { error in
+            print("Is Evolv client initialisation successfull? \(error == nil)")
+        })
     }
 }
-

--- a/EvolvAppExample/EvolvAppExample/ViewController.swift
+++ b/EvolvAppExample/EvolvAppExample/ViewController.swift
@@ -17,7 +17,7 @@ class ViewController: UIViewController {
         super.viewDidLoad()
         // Do any additional setup after loading the view
         
-        let url = HttpConfig.allocationsURL()
+        let url = HttpConfig.configurationURL(domain: HttpConfig.stagingDomain)
         cancellable = EvolvAPI.fetchData(for: url)
             .catch {(error: HTTPError) -> Just<String?> in
                 print("\(error.localizedDescription)")

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvConfigImpl.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvConfigImpl.swift
@@ -15,18 +15,13 @@
 ////  See the License for the specific language governing permissions and
 ////  limitations under the License.
 ////
-//
-//
-//import Foundation
-//
-///// General configurations for the SDK.
+
 struct EvolvConfigImpl: EvolvConfig {
-    
     public enum Default {
         public static let httpScheme: String = HttpConfig.httpScheme
-        public static let domain: String = HttpConfig.devDomain
-        public static let version: String = HttpConfig.apiVersion
-        public static let environmentId: String = HttpConfig.environmentId
+//        public static let domain: String = HttpConfig.devDomain
+//        public static let version: String = HttpConfig.apiVersion
+//        public static let environmentId: String = HttpConfig.environmentId
     }
 
     let httpScheme: String
@@ -34,7 +29,4 @@ struct EvolvConfigImpl: EvolvConfig {
     let version: String
     let environmentId: String
     let httpClient: EvolvHttpClient
-    
-    
-    
 }

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvContextImpl.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvContextImpl.swift
@@ -19,44 +19,32 @@
 
 import Foundation
 
-public class EvolvContextImpl: EvolvContext {
-    
-    private var uid: String
-    private var sid: String?
+public struct EvolvContextImpl: EvolvContext {
     private var remoteContext: [String : Any] = [:]
     private var localContext: [String : Any] = [:]
-    private var initialized = false
     
+    public var configuration: Configuration?
     
-    private var evolvConfig: EvolvConfigImpl?
-    private var evolvStore: EvolvStoreImpl?
-    
-    public required init(uid: String, remoteContext: [String : Any], localContext: [String : Any]) {
-        
-        self.uid = uid
+    public init(remoteContext: [String : Any], localContext: [String : Any]) {
         self.localContext = localContext
         self.remoteContext = remoteContext
     }
     
     public func resolve() -> [String: Any] {
-        var effectiveContext: [String: Any] = [:]
-        return effectiveContext
+        return [:]
     }
     
-    public func set(key: String, value: String, local: Bool = false) -> [String : Any] {
-        
-        var context = local ? localContext : remoteContext
-        context.updateValue(value, forKey: key)
-        return context
+    public mutating func set(key: String, value: Any, local: Bool = false) -> [String : Any] {
+        if local {
+            localContext[key] = value
+            return localContext
+        } else {
+            remoteContext[key] = value
+            return remoteContext
+        }
     }
     
-    func mergeContext(localContext: [String: Any], remoteContext: [String: Any]) -> [String: Any] {
-        
+    func mergeContext(localContext: [String : Any], remoteContext: [String : Any]) -> [String : Any] {
         return remoteContext.merging(localContext) { (current, _) in current }
     }
-    
-    
-    
 }
-
-

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Data Model/Data.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Data Model/Data.swift
@@ -19,6 +19,6 @@
 
 import Foundation
 
-public struct Data: Codable, Equatable {
-    
-}
+//public struct Data: Codable, Equatable {
+//    
+//}

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Protocols/EvolvClient.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Protocols/EvolvClient.swift
@@ -16,9 +16,14 @@
 //  limitations under the License.
 //
 
-import Foundation
+import Combine
 
 public protocol EvolvClient {
+    
+    /// Initialises EvolvClient with desired EvolvClientOptions
+    /// - Parameter options: provide desired options for the Evolv Client.
+    /// - Parameter completionHandler: If the error parameter is nil, the initialisation was successfull, and the object is ready to work with Evolv API.
+    init(options: EvolvClientOptions, completionHandler: @escaping ((Error?) -> Void))
     
     /// Sends a confirmed event to Evolv.
     ///
@@ -35,19 +40,9 @@ public protocol EvolvClient {
     /// that the allocation timed out or failed.
     func contaminate()
     
-    
-    
     /// Get the value of a specified key.
     /// - Parameter forKey: The identifier of the event.
     func get(value forKey: String)
-    
-    /// Initializes the client with required context information.
-    /// - Parameter uid: A globally unique identifier for the current participant.
-    /// - Parameter remoteContext: A map of data used for evaluating context predicates and analytics.
-    /// - Parameter localContext: A map of data used only for evaluating context predicates.
-    func initialize(uid: String, remoteContext: [String: Any], localContext: [String: Any]?)
-    
-    
     
     /// Reevaluates the current context.
     func reevaluateContext()

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Protocols/EvolvContext.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Protocols/EvolvContext.swift
@@ -23,7 +23,7 @@ import Foundation
 /// This data is used for determining which variables are active, and for general analytics.
 public protocol EvolvContext {
     
-    init(uid: String, remoteContext: [String: Any], localContext: [String: Any])
+    init(remoteContext: [String: Any], localContext: [String: Any])
     
 //    /// Checks if the specified key is currently defined in the context.
 //    /// - Parameter key: The key to check.
@@ -53,7 +53,7 @@ public protocol EvolvContext {
     /// - Parameter key: The key to associate the value to.
     /// - Parameter value: The value to associate with the key.
     /// - Parameter local: If true, the value will only be added to the localContext.
-    func set(key: String, value: String, local: Bool) -> [String: Any]
+    mutating func set(key: String, value: Any, local: Bool) -> [String: Any]
     
 //    /// Merge the specified object into the current context.
 //    /// Note: This will cause the effective genome to be recomputed.
@@ -61,4 +61,5 @@ public protocol EvolvContext {
 //    /// - Parameter value: If true, the values will only be added to the localContext.
 //    func update(update: AnyObject, local: Bool)
     
+    var configuration: Configuration? { get set }
 }

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Service/HttpClient/HttpConfig.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Service/HttpClient/HttpConfig.swift
@@ -20,15 +20,9 @@
 import Foundation
 
 public struct HttpConfig {
+    public let options: EvolvClientOptions
+    
     static let httpScheme: String = "https"
-    public static let devDomain: String = "participants.evolv.ai"
-    public static let stagingDomain: String = "participants-stg.evolv.ai"
-    static let apiVersion: String = {
-        return "v\(version)"
-    }()
-    static let version: Int = 1
-    static let participantID: String = "80658403_1629111253538"
-    static let environmentId: String = "4a64e0b2ab"
     static let configurationEndpoint: String = "configuration.json"
     static let allocationsEndpoint: String = "allocations"
     static let eventsEndpoint: String = "events"
@@ -37,13 +31,12 @@ public struct HttpConfig {
     /// Creates URL for allocations endpoint.
     ///
     /// - Parameters:
-    ///   - domain: production domain used by default
     /// - Returns: allocations URL
-    public static func allocationsURL(domain: String = devDomain) -> URL {
+    var allocationsURL: URL {
         var components = URLComponents()
         components.scheme = HttpConfig.httpScheme
-        components.host = domain
-        components.path = "/\(HttpConfig.apiVersion)/\(HttpConfig.environmentId)/\(HttpConfig.participantID)/\(HttpConfig.allocationsEndpoint)"
+        components.host = options.evolvDomain
+        components.path = "/v\(options.apiVersion)/\(options.environmentId)/\(options.participantID)/\(HttpConfig.allocationsEndpoint)"
         let url = components.url!
         return url
     }
@@ -51,13 +44,12 @@ public struct HttpConfig {
     /// Creates URL for configuration endpoint.
     ///
     /// - Parameters:
-    ///   - domain: production domain used by default
     /// - Returns: configuration URL
-    public static func configurationURL(domain: String = devDomain) -> URL {
+    public var configurationURL: URL {
         var components = URLComponents()
         components.scheme = HttpConfig.httpScheme
-        components.host = domain
-        components.path = "/\(HttpConfig.apiVersion)/\(HttpConfig.environmentId)/\(HttpConfig.participantID)/\(HttpConfig.configurationEndpoint)"
+        components.host = options.evolvDomain
+        components.path = "/v\(options.apiVersion)/\(options.environmentId)/\(options.participantID)/\(HttpConfig.configurationEndpoint)"
         let url = components.url!
         return url
     }
@@ -65,13 +57,12 @@ public struct HttpConfig {
     /// Creates URL for events endpoint.
     ///
     /// - Parameters:
-    ///   - domain: production domain used by default
     /// - Returns: events URL
-    public static func eventsURL(domain: String = devDomain) -> URL {
+    public var eventsURL: URL {
         var components = URLComponents()
         components.scheme = HttpConfig.httpScheme
-        components.host = domain
-        components.path = "/\(HttpConfig.apiVersion)/\(HttpConfig.environmentId)/\(HttpConfig.eventsEndpoint)"
+        components.host = options.evolvDomain
+        components.path = "/v\(options.apiVersion)/\(options.environmentId)/\(HttpConfig.eventsEndpoint)"
         let url = components.url!
         return url
     }
@@ -79,13 +70,12 @@ public struct HttpConfig {
     /// Creates URL for data endpoint.
     ///
     /// - Parameters:
-    ///   - domain: production domain used by default
     /// - Returns: data URL
-    public static func dataURL(domain: String = devDomain) -> URL {
+    public var dataURL: URL {
         var components = URLComponents()
         components.scheme = HttpConfig.httpScheme
-        components.host = domain
-        components.path = "/\(HttpConfig.apiVersion)/\(HttpConfig.environmentId)/\(HttpConfig.dataEndpoint)"
+        components.host = options.evolvDomain
+        components.path = "/v\(options.apiVersion)/\(options.environmentId)/\(HttpConfig.dataEndpoint)"
         let url = components.url!
         return url
     }

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Service/HttpClient/HttpConfig.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Service/HttpClient/HttpConfig.swift
@@ -24,12 +24,12 @@ public struct HttpConfig {
     public static let devDomain: String = "participants.evolv.ai"
     public static let stagingDomain: String = "participants-stg.evolv.ai"
     static let apiVersion: String = {
-        return "V\(version)"
+        return "v\(version)"
     }()
     static let version: Int = 1
-    static let participantID: String = "C51EEAFC-724D-47F7-B99A-F3494357F164"
-    static let environmentId: String = "8b50696b6c"
-    static let configurationEndpoint: String = "configurations.json"
+    static let participantID: String = "80658403_1629111253538"
+    static let environmentId: String = "4a64e0b2ab"
+    static let configurationEndpoint: String = "configuration.json"
     static let allocationsEndpoint: String = "allocations"
     static let eventsEndpoint: String = "events"
     static let dataEndpoint: String = "data"
@@ -56,7 +56,7 @@ public struct HttpConfig {
     public static func configurationURL(domain: String = devDomain) -> URL {
         var components = URLComponents()
         components.scheme = HttpConfig.httpScheme
-        components.host = HttpConfig.devDomain
+        components.host = domain
         components.path = "/\(HttpConfig.apiVersion)/\(HttpConfig.environmentId)/\(HttpConfig.participantID)/\(HttpConfig.configurationEndpoint)"
         let url = components.url!
         return url
@@ -70,7 +70,7 @@ public struct HttpConfig {
     public static func eventsURL(domain: String = devDomain) -> URL {
         var components = URLComponents()
         components.scheme = HttpConfig.httpScheme
-        components.host = HttpConfig.devDomain
+        components.host = domain
         components.path = "/\(HttpConfig.apiVersion)/\(HttpConfig.environmentId)/\(HttpConfig.eventsEndpoint)"
         let url = components.url!
         return url
@@ -84,11 +84,9 @@ public struct HttpConfig {
     public static func dataURL(domain: String = devDomain) -> URL {
         var components = URLComponents()
         components.scheme = HttpConfig.httpScheme
-        components.host = HttpConfig.devDomain
+        components.host = domain
         components.path = "/\(HttpConfig.apiVersion)/\(HttpConfig.environmentId)/\(HttpConfig.dataEndpoint)"
         let url = components.url!
         return url
     }
-    
-    
 }

--- a/EvolvSwiftSDK/EvolvSwiftSDKTests/Common-Tests/EvolvStoreTest.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDKTests/Common-Tests/EvolvStoreTest.swift
@@ -41,7 +41,7 @@ class EvolvStoreTest: XCTestCase {
         let remoteContext: [String: Any] = ["test_key" : "test_value"]
         let localContext: [String: Any] = [:]
         
-        let context = EvolvContextImpl(uid: "test_uid", remoteContext: remoteContext, localContext: localContext)
+        var context = EvolvContextImpl(remoteContext: remoteContext, localContext: localContext)
         
         let evolvContext = context.set(key: "new_key", value: "new_value")
         
@@ -54,7 +54,7 @@ class EvolvStoreTest: XCTestCase {
         let remoteContext: [String: Any] = ["test_key1" : "test_value1"]
         let localContext: [String: Any] = ["test_key2" : "test_value2"]
         
-        let context = EvolvContextImpl(uid: "test_uid", remoteContext: remoteContext, localContext: localContext)
+        let context = EvolvContextImpl(remoteContext: remoteContext, localContext: localContext)
         
         XCTAssertEqual(remoteContext.isEmpty, false)
         XCTAssertEqual(localContext.isEmpty, false)
@@ -64,7 +64,7 @@ class EvolvStoreTest: XCTestCase {
         let remoteContext: [String: Any] = ["test_key1" : "test_value1"]
         let localContext: [String: Any] = ["test_key2" : "test_value2"]
         
-        let context = EvolvContextImpl(uid: "test_uid", remoteContext: remoteContext, localContext: localContext)
+        let context = EvolvContextImpl(remoteContext: remoteContext, localContext: localContext)
         
         let evolvContext = context.mergeContext(localContext: localContext, remoteContext: remoteContext)
         

--- a/EvolvSwiftSDK/EvolvSwiftSDKTests/DataModel-Tests/AllocationDataTest.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDKTests/DataModel-Tests/AllocationDataTest.swift
@@ -23,8 +23,8 @@ class AllocationsDataTest: XCTestCase {
         let allocationsData: [Allocation] = try! JSONDecoder().decode([Allocation].self, from: jsonData)
         
         XCTAssertEqual("C51EEAFC-724D-47F7-B99A-F3494357F164", allocationsData[0].userId)
-        XCTAssertEqual("ff01d1516c", allocationsData[0].experimentId)
-        XCTAssertEqual("5fa0fd38aae6:ff01d1516c", allocationsData[0].candidateId)
+        XCTAssertEqual("47d857cd5e", allocationsData[0].experimentId)
+        XCTAssertEqual("5fa0fd38aae6:47d857cd5e", allocationsData[0].candidateId)
     }
 }
 


### PR DESCRIPTION
- `EvolvAPI` (http client): Remove hardcode from the class;
- `EvolvAPI`: make it configurable with `EvolvClientOptions` and not static;
- `EvolvClient`: add `EvolvClientOptions` as a parameter for the initialiser. Users can now provide their own configuration options;
- SDK Tests: change tests according to the new SDK API; change test to comply with provided allocations.json file in the project;
- Demo application: fix the demo app, comply with the new SDK API.