### PR TITLE
Add allocations download upon initialisation.

### DIFF
--- a/EvolvAppExample/EvolvAppExample/ViewController.swift
+++ b/EvolvAppExample/EvolvAppExample/ViewController.swift
@@ -11,6 +11,7 @@ import EvolvSwiftSDK
 
 class ViewController: UIViewController {
     var evolvClient: EvolvClient?
+    var cancellables = Set<AnyCancellable>()
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -21,10 +22,17 @@ class ViewController: UIViewController {
         
         // Initialise and populate EvolvClient with desired options.
         // Store this object to work with it later.
-        // After the completionHandler is fired and the error is nil,
-        // the EvolvClient is ready to be worked with.
-        evolvClient = EvolvClientImpl(options: options, completionHandler: { error in
-            print("Is Evolv client initialisation successfull? \(error == nil)")
-        })
+        EvolvClientImpl.initialize(options: options)
+            .sink(receiveCompletion: { publisherResult in
+                switch publisherResult {
+                case .finished:
+                    print("Evolv client initialization is finished successfully.")
+                case .failure(let error):
+                    print("Evolv client initialization is finished with error: \(error.localizedDescription)")
+                }
+            }, receiveValue: { evolvClient in
+                self.evolvClient = evolvClient
+            })
+            .store(in: &cancellables)
     }
 }

--- a/EvolvSwiftSDK/EvolvSwiftSDK.xcodeproj/project.pbxproj
+++ b/EvolvSwiftSDK/EvolvSwiftSDK.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5924905426CD20060018CFF9 /* Combine+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5924905326CD20060018CFF9 /* Combine+Extensions.swift */; };
 		8D5799902678E8A3009CFA98 /* EvolvConfigImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D57998F2678E8A3009CFA98 /* EvolvConfigImpl.swift */; };
 		8D5799942678F117009CFA98 /* EvolvResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D5799932678F117009CFA98 /* EvolvResult.swift */; };
 		8D5799982678F5DC009CFA98 /* EvolvContextImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D5799972678F5DC009CFA98 /* EvolvContextImpl.swift */; };
@@ -73,6 +74,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		5924905326CD20060018CFF9 /* Combine+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Combine+Extensions.swift"; sourceTree = "<group>"; };
 		8D57998F2678E8A3009CFA98 /* EvolvConfigImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvolvConfigImpl.swift; sourceTree = "<group>"; };
 		8D5799932678F117009CFA98 /* EvolvResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvolvResult.swift; sourceTree = "<group>"; };
 		8D5799972678F5DC009CFA98 /* EvolvContextImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvolvContextImpl.swift; sourceTree = "<group>"; };
@@ -150,6 +152,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		5924905226CD1FF60018CFF9 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				5924905326CD20060018CFF9 /* Combine+Extensions.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		8D9C6072266F7E230011EC8A = {
 			isa = PBXGroup;
 			children = (
@@ -186,7 +196,7 @@
 			isa = PBXGroup;
 			children = (
 				8D9C6114266FAB420011EC8A /* Protocols */,
-				8D9C6111266F8CC10011EC8A /* Extensions */,
+				5924905226CD1FF60018CFF9 /* Extensions */,
 				8D9C6110266F8C450011EC8A /* Data Model */,
 				8D9C60E3266F88630011EC8A /* Core */,
 				8D9C60E9266F88630011EC8A /* Constants */,
@@ -296,13 +306,6 @@
 				8D9C61172670090D0011EC8A /* Data.swift */,
 			);
 			path = "Data Model";
-			sourceTree = "<group>";
-		};
-		8D9C6111266F8CC10011EC8A /* Extensions */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			path = Extensions;
 			sourceTree = "<group>";
 		};
 		8D9C6114266FAB420011EC8A /* Protocols */ = {
@@ -502,6 +505,7 @@
 				8DE7B37E26710D17003E76A7 /* EvolvPredicateImpl.swift in Sources */,
 				8D9C6104266F88640011EC8A /* LogOutput.swift in Sources */,
 				8D9C60FF266F88640011EC8A /* EvolvStoreImpl.swift in Sources */,
+				5924905426CD20060018CFF9 /* Combine+Extensions.swift in Sources */,
 				8DD4F36626832CAF002134B7 /* EvolvBeacon.swift in Sources */,
 				8D9C610A266F88640011EC8A /* Allocation.swift in Sources */,
 				8D9C610C266F88640011EC8A /* EvolvAPI.swift in Sources */,

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvContextImpl.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvContextImpl.swift
@@ -23,8 +23,6 @@ public struct EvolvContextImpl: EvolvContext {
     private var remoteContext: [String : Any] = [:]
     private var localContext: [String : Any] = [:]
     
-    public var configuration: Configuration?
-    
     public init(remoteContext: [String : Any], localContext: [String : Any]) {
         self.localContext = localContext
         self.remoteContext = remoteContext

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Extensions/Combine+Extensions.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Extensions/Combine+Extensions.swift
@@ -1,0 +1,23 @@
+//
+//  Combine+Extensions.swift
+//  EvolvSwiftSDK
+//
+//  Created by Alim Yuzbashev on 18.08.2021.
+//
+
+import Combine
+
+extension Subscribers.Completion {
+    func resultRepresentation<T>(withSuccessCase successCase: T) -> Result<T, Failure> {
+        let result: Result<T, Failure>
+        
+        switch self {
+        case .finished:
+            result = .success(successCase)
+        case .failure(let error):
+            result = .failure(error)
+        }
+        
+        return result
+    }
+}

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Protocols/EvolvClient.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Protocols/EvolvClient.swift
@@ -21,9 +21,9 @@ import Combine
 public protocol EvolvClient {
     
     /// Initialises EvolvClient with desired EvolvClientOptions
-    /// - Parameter options: provide desired options for the Evolv Client.
-    /// - Parameter completionHandler: If the error parameter is nil, the initialisation was successfull, and the object is ready to work with Evolv API.
-    init(options: EvolvClientOptions, completionHandler: @escaping ((Error?) -> Void))
+    /// - Parameter options: Provide desired options for the EvolvClient.
+    /// - Returns: Publisher for the EvolvClient object.
+    static func initialize(options: EvolvClientOptions) -> AnyPublisher<EvolvClient, Error>
     
     /// Sends a confirmed event to Evolv.
     ///

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Protocols/EvolvContext.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Protocols/EvolvContext.swift
@@ -60,6 +60,4 @@ public protocol EvolvContext {
 //    /// - Parameter update: The values to update the context with.
 //    /// - Parameter value: If true, the values will only be added to the localContext.
 //    func update(update: AnyObject, local: Bool)
-    
-    var configuration: Configuration? { get set }
 }

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Service/HttpClient/EvolvAPI.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Service/HttpClient/EvolvAPI.swift
@@ -34,7 +34,7 @@ struct EvolvAPI {
     /// - Returns: publisher for the data task.
     public func fetchData(for url: URL) -> AnyPublisher<Data?, HTTPError> {
         return session.dataTaskPublisher(for: url)
-            .mapError{ HTTPError.networkingError($0) }
+            .mapError { HTTPError.networkingError($0) }
             .print()
             .tryMap {
                 guard let httpResponse = $0.response as? HTTPURLResponse else {


### PR DESCRIPTION
- Add allocations download upon initialisation of `EvolvClientImpl`; 
- Refactor `EvolvClient` initialisation:
  - Use `Combine` instead of completion handlers for initialisation safety and simplicity;
  - Move `Configuration` download to `EvolvStoreImpl`.