### PR TITLE
EvolvClient: getActiveKeys() initial implementation.

### DIFF
--- a/EvolvAppExample/EvolvAppExample/ViewController.swift
+++ b/EvolvAppExample/EvolvAppExample/ViewController.swift
@@ -10,7 +10,7 @@ import Combine
 import EvolvSwiftSDK
 
 class ViewController: UIViewController {
-    var evolvClient: EvolvClient?
+    var evolvClient: EvolvClient!
     var cancellables = Set<AnyCancellable>()
 
     override func viewDidLoad() {
@@ -18,7 +18,9 @@ class ViewController: UIViewController {
         
         // Initialise options for the EvolvClient.
         // Provide your credentials for the Evolv API.
-        let options = EvolvClientOptions(evolvDomain: "participants-stg.evolv.ai", participantID: "80658403_1629111253538", environmentId: "4a64e0b2ab")
+        let options = EvolvClientOptions(evolvDomain: "participants-stg.evolv.ai", participantID: "80658403_1629111253538", environmentId: "4a64e0b2ab",
+                                         localContext: ["location" : "UA",
+                                                        "age" : "25"])
         
         // Initialise and populate EvolvClient with desired options.
         // Store this object to work with it later.
@@ -27,6 +29,7 @@ class ViewController: UIViewController {
                 switch publisherResult {
                 case .finished:
                     print("Evolv client initialization is finished successfully.")
+                    self.showcaseEvolvClient()
                 case .failure(let error):
                     print("Evolv client initialization is finished with error: \(error.localizedDescription)")
                 }
@@ -34,5 +37,9 @@ class ViewController: UIViewController {
                 self.evolvClient = evolvClient
             })
             .store(in: &cancellables)
+    }
+    
+    func showcaseEvolvClient() {
+        print("Active keys: \(evolvClient.getActiveKeys())")
     }
 }

--- a/EvolvSwiftSDK/EvolvSwiftSDK.xcodeproj/project.pbxproj
+++ b/EvolvSwiftSDK/EvolvSwiftSDK.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		595FABFB26CE73910023A1D9 /* EvolvAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 595FABFA26CE73910023A1D9 /* EvolvAPI.swift */; };
 		595FABFE26CE741C0023A1D9 /* EvolvAPIMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 595FABFD26CE741C0023A1D9 /* EvolvAPIMock.swift */; };
 		595FAC0226CE94610023A1D9 /* EvolvClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 595FAC0126CE94610023A1D9 /* EvolvClientTests.swift */; };
+		596C641426CFBFD9002516C5 /* Foundation+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 596C641326CFBFD9002516C5 /* Foundation+Extensions.swift */; };
 		8D5799902678E8A3009CFA98 /* EvolvConfigImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D57998F2678E8A3009CFA98 /* EvolvConfigImpl.swift */; };
 		8D5799942678F117009CFA98 /* EvolvResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D5799932678F117009CFA98 /* EvolvResult.swift */; };
 		8D5799982678F5DC009CFA98 /* EvolvContextImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D5799972678F5DC009CFA98 /* EvolvContextImpl.swift */; };
@@ -83,6 +84,7 @@
 		595FABFA26CE73910023A1D9 /* EvolvAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvolvAPI.swift; sourceTree = "<group>"; };
 		595FABFD26CE741C0023A1D9 /* EvolvAPIMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvolvAPIMock.swift; sourceTree = "<group>"; };
 		595FAC0126CE94610023A1D9 /* EvolvClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvolvClientTests.swift; sourceTree = "<group>"; };
+		596C641326CFBFD9002516C5 /* Foundation+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Foundation+Extensions.swift"; sourceTree = "<group>"; };
 		8D57998F2678E8A3009CFA98 /* EvolvConfigImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvolvConfigImpl.swift; sourceTree = "<group>"; };
 		8D5799932678F117009CFA98 /* EvolvResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvolvResult.swift; sourceTree = "<group>"; };
 		8D5799972678F5DC009CFA98 /* EvolvContextImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvolvContextImpl.swift; sourceTree = "<group>"; };
@@ -164,6 +166,7 @@
 			isa = PBXGroup;
 			children = (
 				5924905326CD20060018CFF9 /* Combine+Extensions.swift */,
+				596C641326CFBFD9002516C5 /* Foundation+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -495,6 +498,7 @@
 				8D9A1BE5268DD5CD00B302E6 /* Context.swift in Sources */,
 				8D9C60FD266F88630011EC8A /* EvolvContext.swift in Sources */,
 				8D9A1BE3268DAC8300B302E6 /* EvolvEmitter.swift in Sources */,
+				596C641426CFBFD9002516C5 /* Foundation+Extensions.swift in Sources */,
 				8D9C610B266F88640011EC8A /* Configuration.swift in Sources */,
 				8DE7B38F26739423003E76A7 /* TypeCheckingConversion.swift in Sources */,
 				8D9C6102266F88640011EC8A /* HttpConfig.swift in Sources */,

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvClientImpl.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvClientImpl.swift
@@ -53,6 +53,10 @@ public final class EvolvClientImpl: EvolvClient {
         }
     }
     
+    public func getActiveKeys() -> [String] {
+        evolvStore.getActiveKeys()
+    }
+    
     public func confirm() {
         return
     }

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvContextImpl.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvContextImpl.swift
@@ -20,8 +20,12 @@
 import Foundation
 
 public struct EvolvContextImpl: EvolvContext {
-    private var remoteContext: [String : Any] = [:]
-    private var localContext: [String : Any] = [:]
+    private(set) var remoteContext: [String : Any] = [:]
+    private(set) var localContext: [String : Any] = [:]
+    
+    var mergedContext: [String : Any] {
+        remoteContext.merging(localContext, uniquingKeysWith: { (l, r) in r })
+    }
     
     public init(remoteContext: [String : Any], localContext: [String : Any]) {
         self.localContext = localContext

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvStoreImpl.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvStoreImpl.swift
@@ -30,7 +30,6 @@ public class EvolvStoreImpl: EvolvStore {
     private var keyStates: KeyStates
     private var configKeyStates = KeyStates();
     private var genomeKeyStates = KeyStates();
-    private var evolvPredicate = EvolvPredicateImpl()
     private let evolvAPI: EvolvAPI
     
     private var reevaluatingContext: Bool = false
@@ -83,6 +82,42 @@ public class EvolvStoreImpl: EvolvStore {
         
     }
     
+    private func isActive(key: String) -> Bool {
+        guard let experiment = evolvConfiguration.experiments.first(where: { $0.id == key }) else { return false }
+        
+        return isActive(experiment: experiment)
+    }
+    
+    private func evaluatePredicates(context: EvolvContext, configuration: Configuration) {
+        
+    }
+    
+    private func isActive(experiment: ExperimentCollection) -> Bool {
+        guard let predicate = experiment.predicate else { return false }
+        
+        let result: Bool
+        
+        switch predicate.combinator {
+        case .and:
+            result = predicate.rules?.allSatisfy { rule in
+                rule.evaluateRule(value: evolvContext.mergedContext[rule.field] as? String ?? "")
+            } == true
+        case .or:
+            result = predicate.rules?.contains { rule in
+                rule.evaluateRule(value: evolvContext.mergedContext[rule.field] as? String ?? "")
+            } == true
+        }
+        
+        return result
+    }
+    
+    private func isActive(experiment: Experiment) {
+        
+    }
+    
+    private func evaluateFilter(userValue: String, against rule: Rule) {
+        
+    }
 }
 
 
@@ -140,7 +175,7 @@ extension EvolvStoreImpl {
         return []
     }
     
-    public func evaluatePredicates(version: Int, context: EvolvContext, config: Configuration) -> [String: Any]{
+    func evaluatePredicates(version: Int, context: EvolvContext, config: Configuration) -> [String: Any]{
         
         let result = [String: Any]()
         if (config.experiments.count == 0) {
@@ -155,7 +190,7 @@ extension EvolvStoreImpl {
         // TODO: - Add functionality (lines 216-240)
     }
     
-    public func setActiveAndEntryKeyStates(version: Int, context: EvolvContext, allocations: Allocation,  config: Configuration, configKeyStates: [String: Any]) {
+    func setActiveAndEntryKeyStates(version: Int, context: EvolvContext, allocations: Allocation,  config: Configuration, configKeyStates: [String: Any]) {
         // TODO: - Add functionality 242-287
     }
     

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvStoreImpl.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvStoreImpl.swift
@@ -72,7 +72,7 @@ public class EvolvStoreImpl: EvolvStore {
     }
     
     func isActive(key: String) -> Bool {
-        guard let experimentCollection = evolvConfiguration.experiments.first,
+        guard let experimentCollection = evolvConfiguration.experiments.first(where: { $0.experiments.contains { $0.name == key } }),
               let experiment = experimentCollection.experiments.first(where: { $0.name == key })
         else { return false }
         

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvStoreImpl.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvStoreImpl.swift
@@ -83,36 +83,23 @@ public class EvolvStoreImpl: EvolvStore {
     }
     
     private func isActive(key: String) -> Bool {
-        guard let experiment = evolvConfiguration.experiments.first(where: { $0.id == key }) else { return false }
+        guard let experimentCollection = evolvConfiguration.experiments.first,
+              let experiment = experimentCollection.experiments.first(where: { $0.name == key })
+        else { return false }
         
-        return isActive(experiment: experiment)
+        return isActive(experimentCollection: experimentCollection) && isActive(experiment: experiment)
     }
     
     private func evaluatePredicates(context: EvolvContext, configuration: Configuration) {
         
     }
     
-    private func isActive(experiment: ExperimentCollection) -> Bool {
-        guard let predicate = experiment.predicate else { return false }
-        
-        let result: Bool
-        
-        switch predicate.combinator {
-        case .and:
-            result = predicate.rules?.allSatisfy { rule in
-                rule.evaluateRule(value: evolvContext.mergedContext[rule.field] as? String ?? "")
-            } == true
-        case .or:
-            result = predicate.rules?.contains { rule in
-                rule.evaluateRule(value: evolvContext.mergedContext[rule.field] as? String ?? "")
-            } == true
-        }
-        
-        return result
+    private func isActive(experimentCollection: ExperimentCollection) -> Bool {
+        experimentCollection.predicate?.isActive(in: evolvContext.mergedContext) ?? true
     }
     
-    private func isActive(experiment: Experiment) {
-        
+    private func isActive(experiment: Experiment) -> Bool {
+        experiment.predicate?.isActive(in: evolvContext.mergedContext) ?? true
     }
     
     private func evaluateFilter(userValue: String, against rule: Rule) {

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvStoreImpl.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvStoreImpl.swift
@@ -71,8 +71,22 @@ public class EvolvStoreImpl: EvolvStore {
         var experiments = Array<String>()
     }
     
-    private func update(configRequest: Bool, requestedKeys: [String], value: Any) {
+    func isActive(key: String) -> Bool {
+        guard let experimentCollection = evolvConfiguration.experiments.first,
+              let experiment = experimentCollection.experiments.first(where: { $0.name == key })
+        else { return false }
         
+        return isActive(experimentCollection: experimentCollection) && isActive(experiment: experiment)
+    }
+    
+    func getActiveKeys() -> [String] {
+        evolvConfiguration.experiments
+            .flatMap { $0.experiments }
+            .map { $0.name }
+            .filter { isActive(key: $0) }
+    }
+    
+    private func update(configRequest: Bool, requestedKeys: [String], value: Any) {
         keyStates = configRequest ? configKeyStates : genomeKeyStates
         
         reevaluateContext()
@@ -80,14 +94,6 @@ public class EvolvStoreImpl: EvolvStore {
     
     private func reevaluateContext() {
         
-    }
-    
-    private func isActive(key: String) -> Bool {
-        guard let experimentCollection = evolvConfiguration.experiments.first,
-              let experiment = experimentCollection.experiments.first(where: { $0.name == key })
-        else { return false }
-        
-        return isActive(experimentCollection: experimentCollection) && isActive(experiment: experiment)
     }
     
     private func evaluatePredicates(context: EvolvContext, configuration: Configuration) {
@@ -157,13 +163,11 @@ extension EvolvStoreImpl {
     
     func activeEntryPoints(entryKeys: [String: Any]) -> [String] {
         var eids: [String] = []
-//        TODO: implement function
         
         return []
     }
     
     func evaluatePredicates(version: Int, context: EvolvContext, config: Configuration) -> [String: Any]{
-        
         let result = [String: Any]()
         if (config.experiments.count == 0) {
             return result
@@ -180,10 +184,4 @@ extension EvolvStoreImpl {
     func setActiveAndEntryKeyStates(version: Int, context: EvolvContext, allocations: Allocation,  config: Configuration, configKeyStates: [String: Any]) {
         // TODO: - Add functionality 242-287
     }
-    
-    
-    
-    
-    
-    
 }

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvStoreImpl.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvStoreImpl.swift
@@ -79,6 +79,7 @@ public class EvolvStoreImpl: EvolvStore {
         return isActive(experimentCollection: experimentCollection) && isActive(experiment: experiment)
     }
     
+    // TODO: Doesn't work correctly with nested rules and keys.
     func getActiveKeys() -> [String] {
         evolvConfiguration.experiments
             .flatMap { $0.experiments }

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Data Model/Configuration.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Data Model/Configuration.swift
@@ -229,4 +229,17 @@ public struct ExperimentPredicate: Codable, Equatable {
         case and = "and"
         case or = "or"
     }
+    
+    func isActive(in context: [String : Any]) -> Bool {
+        switch combinator {
+        case .and:
+            return rules?.allSatisfy { rule in
+                rule.evaluateRule(value: context[rule.field] as? String ?? "")
+            } == true
+        case .or:
+            return rules?.contains { rule in
+                rule.evaluateRule(value: context[rule.field] as? String ?? "")
+            } == true
+        }
+    }
 }

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Data Model/Configuration.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Data Model/Configuration.swift
@@ -50,7 +50,7 @@ public struct Client: Codable, Equatable {
 
 // MARK: - Experiment
 public struct ExperimentCollection: Equatable {
-    let predicate: ExperimentPredicate
+    let predicate: ExperimentPredicate?
     let id: String
     let paused: Bool
     let experiments: [Experiment]
@@ -68,15 +68,12 @@ public struct ExperimentCollection: Equatable {
               let paused = keyValues[CodingKeys.paused.rawValue] as? Bool
         else { return nil }
         
-        guard let predicateData = try? JSONSerialization.data(withJSONObject: predicateKV, options: []),
-              let predicate = try? JSONDecoder().decode(ExperimentPredicate.self, from: predicateData)
-        else { return nil }
-        
-        self.predicate = predicate
         self.id = id
         self.paused = paused
         
-        let experiments: [Experiment] = keyValues.withoutValues(withKeys: [CodingKeys.predicate, .id, .paused, .web].map { $0.rawValue })
+        self.predicate = try? JSONDecoder().decode(ExperimentPredicate.self, fromJSONObject: predicateKV)
+        
+        self.experiments = keyValues.withoutValues(withKeys: [CodingKeys.predicate, .id, .paused, .web].map { $0.rawValue })
             .map { ($0.key, $0.value) }
             .compactMap { (name, value) in
             let result: Experiment?
@@ -91,7 +88,12 @@ public struct ExperimentCollection: Equatable {
             
             return result
         }
-        
+    }
+    
+    init(predicate: ExperimentPredicate, id: String, paused: Bool, experiments: [Experiment]) {
+        self.predicate = predicate
+        self.id = id
+        self.paused = paused
         self.experiments = experiments
     }
 }

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Data Model/Configuration.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Data Model/Configuration.swift
@@ -76,18 +76,21 @@ public struct ExperimentCollection: Equatable {
         self.experiments = keyValues.withoutValues(withKeys: [CodingKeys.predicate, .id, .paused, .web].map { $0.rawValue })
             .map { ($0.key, $0.value) }
             .compactMap { (name, value) in
-            let result: Experiment?
-            
-            if let experimentData = try? JSONSerialization.data(withJSONObject: value, options: []),
-               var experiment = try? JSONDecoder().decode(Experiment.self, from: experimentData) {
-                experiment.name = name
-                result = experiment
-            } else {
-                result = nil
+                let result: Experiment?
+                
+                do {
+                    let experimentData = try JSONSerialization.data(withJSONObject: value, options: [])
+                    var experiment = try JSONDecoder().decode(Experiment.self, from: experimentData)
+                    
+                    experiment.name = name
+                    result = experiment
+                } catch {
+                    print("Evolv: error while deserializing Configuration.json. Error: \(error)")
+                    result = nil
+                }
+                
+                return result
             }
-            
-            return result
-        }
     }
     
     init(predicate: ExperimentPredicate, id: String, paused: Bool, experiments: [Experiment]) {
@@ -102,7 +105,7 @@ public struct Experiment: Codable, Equatable {
     var name: String = ""
     let isEntryPoint: Bool
     let predicate: ExperimentPredicate?
-    let values: Bool
+    let values: Bool?
     let initializers: Bool
     
     private enum CodingKeys: String, CodingKey {

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Extensions/Foundation+Extensions.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Extensions/Foundation+Extensions.swift
@@ -1,0 +1,36 @@
+//
+//  Swift+Extensions.swift
+//  EvolvSwiftSDK
+//
+//  Created by Alim Yuzbashev on 20.08.2021.
+//
+
+import Foundation
+
+extension String {
+    func regexMatch(regex: String) -> Bool {
+        do {
+            let regex = try NSRegularExpression(pattern: regex)
+            let firstMatch = regex.firstMatch(in: self, range: NSRange(self.startIndex..., in: self))
+            
+            return firstMatch?.range.length != 0
+        } catch {
+            print("Evolv: invalid regex. Regex: \(regex), text: \(self). Error: \(error)")
+            return false
+        }
+    }
+}
+
+extension Dictionary {
+    mutating func removeValues(forKeys keys: [Key]) {
+        keys.forEach {
+            self.removeValue(forKey: $0)
+        }
+    }
+    
+    func withoutValues(withKeys keys: [Key]) -> Self {
+        var dict = self
+        dict.removeValues(forKeys: keys)
+        return dict
+    }
+}

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Extensions/Foundation+Extensions.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Extensions/Foundation+Extensions.swift
@@ -34,3 +34,11 @@ extension Dictionary {
         return dict
     }
 }
+
+extension JSONDecoder {
+    func decode<T: Decodable>(_ type: T.Type, fromJSONObject obj: Any, options: JSONSerialization.WritingOptions = []) throws -> T {
+        let data = try JSONSerialization.data(withJSONObject: obj, options: options)
+        
+        return try self.decode(type, from: data)
+    }
+}

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Protocols/EvolvClient.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Protocols/EvolvClient.swift
@@ -46,89 +46,92 @@ public protocol EvolvClient {
     
     /// Reevaluates the current context.
     func reevaluateContext()
+    
+    /// Gets active keys.
+    func getActiveKeys() -> [String]
 }
 
 // MARK: - Default implementation and optional protocol methods
-extension EvolvClient {
-    
-    /// Check all active keys that start with the specified prefix.
-    /// - Parameter prefix: The prefix of the keys to check.
-    func getActiveKeys(for prefix: String) -> Bool { 
-        return true
-    }
-    
-    //    Deprecated
-    /// Clears the active keys to reset the key states.
-    /// - Parameter prefix: The prefix of the keys clear.
-    func clearActiveKeys(for prefix: String) -> Bool {
-        return true
-    }
-    
-    /// If the client was configured with bufferEvents: true then calling this will allow data to be sent back to Evolv
-    func allowEvents() -> Bool {
-        return true
-    }
-    
-    /// Destroy the client and its dependencies.
-    func destroy() -> Bool {
-        return true
-    }
-    
-    /// Emits a generic event to be recorded by Evolv.
-    ///
-    /// Sends an event to Evolv to be recorded and reported upon.
-    ///
-    /// - Parameter key: The identifier of the event.
-    func emit(for key: String) -> Bool {
-        return true
-    }
-    
-    /// Force all beacons to transmit.
-    func flush() -> Bool {
-        return true
-    }
-    
-    /// Check if a specified key is currently active.
-    /// - Parameter key: The key to check.
-    func isActive(for key: String) -> Bool {
-        return true
-    }
-    
-//    TODO: check method and implementation in Javascript SDK
-    /// Add listeners to lifecycle events that take place in to client.
-    /// See Constants/Events for currently supported events
-    /// - Parameter topic: The event topic on which the listener should be invoked.
-    /// - Parameter listener: The listener to be invoked for the specified topic.
-    func on(with topic: String, for listener: () -> ()) -> Bool {
-        return true
-    }
-    
-//    TODO: check method and implementation in Javascript SDK
-    /// Add a listener to a lifecycle event to be invoked once on the next instance of the event to take place in to client.
-    /// See Constants/Events for currently supported events
-    /// - Parameter topic: The event topic on which the listener should be invoked.
-    /// - Parameter listener: The listener to be invoked for the specified topic.
-    func once(with topic: String, for listener: () -> ()) -> Bool {
-        return true
-    }
-    
-//    TODO: check method and implementation in Javascript SDK
-    /// Preload all keys under under the specified prefixes.
-    /// - Parameter prefixes: A list of prefixes to keys to load.
-    /// - Parameter configOnly: If true, only the config would be loaded. (default: false)
-    /// - Parameter immediate: Forces the requests to the server. (default: false)
-    func preload(for prefixes: [String: String], with configOnly: Bool, immediate: Bool) -> Bool {
-        return true
-    }
-    
-    /// Get the configuration for a specified key.
-    /// - Parameter key: The key to retrieve the configuration for.
-    func getConfig(for key: String) -> Bool {
-        return true
-    }
-    
-    
-    
-    
-    
-}
+//extension EvolvClient {
+//
+//    /// Check all active keys that start with the specified prefix.
+//    /// - Parameter prefix: The prefix of the keys to check.
+//    func getActiveKeys(for prefix: String) -> Bool {
+//        return true
+//    }
+//
+//    //    Deprecated
+//    /// Clears the active keys to reset the key states.
+//    /// - Parameter prefix: The prefix of the keys clear.
+//    func clearActiveKeys(for prefix: String) -> Bool {
+//        return true
+//    }
+//
+//    /// If the client was configured with bufferEvents: true then calling this will allow data to be sent back to Evolv
+//    func allowEvents() -> Bool {
+//        return true
+//    }
+//
+//    /// Destroy the client and its dependencies.
+//    func destroy() -> Bool {
+//        return true
+//    }
+//
+//    /// Emits a generic event to be recorded by Evolv.
+//    ///
+//    /// Sends an event to Evolv to be recorded and reported upon.
+//    ///
+//    /// - Parameter key: The identifier of the event.
+//    func emit(for key: String) -> Bool {
+//        return true
+//    }
+//
+//    /// Force all beacons to transmit.
+//    func flush() -> Bool {
+//        return true
+//    }
+//
+//    /// Check if a specified key is currently active.
+//    /// - Parameter key: The key to check.
+//    func isActive(for key: String) -> Bool {
+//        return true
+//    }
+//
+////    TODO: check method and implementation in Javascript SDK
+//    /// Add listeners to lifecycle events that take place in to client.
+//    /// See Constants/Events for currently supported events
+//    /// - Parameter topic: The event topic on which the listener should be invoked.
+//    /// - Parameter listener: The listener to be invoked for the specified topic.
+//    func on(with topic: String, for listener: () -> ()) -> Bool {
+//        return true
+//    }
+//
+////    TODO: check method and implementation in Javascript SDK
+//    /// Add a listener to a lifecycle event to be invoked once on the next instance of the event to take place in to client.
+//    /// See Constants/Events for currently supported events
+//    /// - Parameter topic: The event topic on which the listener should be invoked.
+//    /// - Parameter listener: The listener to be invoked for the specified topic.
+//    func once(with topic: String, for listener: () -> ()) -> Bool {
+//        return true
+//    }
+//
+////    TODO: check method and implementation in Javascript SDK
+//    /// Preload all keys under under the specified prefixes.
+//    /// - Parameter prefixes: A list of prefixes to keys to load.
+//    /// - Parameter configOnly: If true, only the config would be loaded. (default: false)
+//    /// - Parameter immediate: Forces the requests to the server. (default: false)
+//    func preload(for prefixes: [String: String], with configOnly: Bool, immediate: Bool) -> Bool {
+//        return true
+//    }
+//
+//    /// Get the configuration for a specified key.
+//    /// - Parameter key: The key to retrieve the configuration for.
+//    func getConfig(for key: String) -> Bool {
+//        return true
+//    }
+//
+//
+//
+//
+//
+//}

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Protocols/EvolvContext.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Protocols/EvolvContext.swift
@@ -21,7 +21,12 @@ import Foundation
 
 /// The EvolvContext provides functionality to manage data relating to the client state, or context in which the variants will be applied.
 /// This data is used for determining which variables are active, and for general analytics.
-public protocol EvolvContext {
+internal protocol EvolvContext {
+    var remoteContext: [String : Any] { get }
+    
+    var localContext: [String : Any] { get }
+    
+    var mergedContext: [String : Any] { get }
     
     init(remoteContext: [String: Any], localContext: [String: Any])
     

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Protocols/EvolvStore.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Protocols/EvolvStore.swift
@@ -23,4 +23,8 @@ import Foundation
 protocol EvolvStore {
     var evolvAllocations: [Allocation] { get }
     var evolvConfiguration: Configuration { get }
+    
+    func isActive(key: String) -> Bool
+    
+    func getActiveKeys() -> [String]
 }

--- a/EvolvSwiftSDK/EvolvSwiftSDKTests/Common-Tests/EvolvStoreTest.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDKTests/Common-Tests/EvolvStoreTest.swift
@@ -81,9 +81,9 @@ class EvolvStoreTest: XCTestCase {
         
         let rules: [Rule] = [Rule(field: "Age", ruleOperator: Rule.RuleOperator(rawValue: "equal")!, value: "26")]
         
-        let experimentPredicate: ExperimentPredicate? = ExperimentPredicate(id: 174, combinator: "and", rules: rules)
+        let experimentPredicate: ExperimentPredicate? = ExperimentPredicate(id: 174, combinator: .and, rules: rules)
         
-        let experiment: Experiment = Experiment(predicate: experimentPredicate!, id: "47d857cd5e", paused: false)
+        let experiment: ExperimentCollection = ExperimentCollection(predicate: experimentPredicate!, id: "47d857cd5e", paused: false)
         
 //        let keyStates: [String: Any] = ["experiments":
 //                                            [Array(["123":

--- a/EvolvSwiftSDK/EvolvSwiftSDKTests/Common-Tests/EvolvStoreTest.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDKTests/Common-Tests/EvolvStoreTest.swift
@@ -79,11 +79,11 @@ class EvolvStoreTest: XCTestCase {
         
         var keyStates: KeyStates?
         
-        let rules: [Rule] = [Rule(field: "Age", ruleOperator: Rule.RuleOperator(rawValue: "equal")!, value: "26")]
+        let rules = [Rule(field: "Age", ruleOperator: Rule.RuleOperator(rawValue: "equal")!, value: "26")]
         
-        let experimentPredicate: ExperimentPredicate? = ExperimentPredicate(id: 174, combinator: .and, rules: rules)
+        let experimentPredicate = ExperimentPredicate(id: 174, combinator: .and, rules: rules)
         
-        let experiment: ExperimentCollection = ExperimentCollection(predicate: experimentPredicate!, id: "47d857cd5e", paused: false)
+        let experiments = ExperimentCollection(predicate: experimentPredicate, id: "47d857cd5e", paused: false, experiments: [])
         
 //        let keyStates: [String: Any] = ["experiments":
 //                                            [Array(["123":

--- a/EvolvSwiftSDK/EvolvSwiftSDKTests/Common-Tests/EvolvStoreTest.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDKTests/Common-Tests/EvolvStoreTest.swift
@@ -83,7 +83,7 @@ class EvolvStoreTest: XCTestCase {
         
         let experimentPredicate = ExperimentPredicate(id: 174, combinator: .and, rules: rules)
         
-        let experiments = ExperimentCollection(predicate: experimentPredicate, id: "47d857cd5e", paused: false, experiments: [])
+//        let experiments = ExperimentCollection(predicate: experimentPredicate, id: "47d857cd5e", paused: false, experiments: [])
         
 //        let keyStates: [String: Any] = ["experiments":
 //                                            [Array(["123":

--- a/EvolvSwiftSDK/EvolvSwiftSDKTests/DataModel-Tests/ConfigurationDataTest.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDKTests/DataModel-Tests/ConfigurationDataTest.swift
@@ -43,7 +43,7 @@ class ConfigurationDataTest: XCTestCase {
     func testCanParseConfigurationJSONFile() throws {
         XCTAssertEqual("desktop", configurationData.client.device)
         XCTAssertEqual("BY", configurationData.client.location)
-        XCTAssertEqual(156, configurationData.experiments[1].predicate.id)
+        XCTAssertEqual(156, configurationData.experiments[1].predicate?.id)
         XCTAssertEqual("ff01d1516c", configurationData.experiments[0].id)
         XCTAssertEqual(false, configurationData.experiments[0].paused)
     }

--- a/EvolvSwiftSDK/EvolvSwiftSDKTests/TestingData/configuration.json
+++ b/EvolvSwiftSDK/EvolvSwiftSDKTests/TestingData/configuration.json
@@ -9,7 +9,32 @@
     "_experiments": [
         {
             "web": {},
-            "_predicate": {},
+            "_predicate": {
+                "id": 1165,
+                "combinator": "and",
+                "rules": [
+                    {
+                        "field": "location",
+                        "operator": "equal",
+                        "value": "UA"
+                    },
+                    {
+                        "combinator": "or",
+                        "rules": [
+                            {
+                                "field": "location",
+                                "operator": "equal",
+                                "value": "UA"
+                            },
+                            {
+                                "field": "Student",
+                                "operator": "contains",
+                                "value": "High_school"
+                            }
+                        ]
+                    }
+                ]
+            },
             "home": {
                 "_is_entry_point": true,
                 "_predicate": {
@@ -23,6 +48,12 @@
                     ]
                 },
                 "cta_text": {
+                    "_is_entry_point": false,
+                    "_predicate": null,
+                    "_values": true,
+                    "_initializers": true
+                },
+                "background": {
                     "_is_entry_point": false,
                     "_predicate": null,
                     "_values": true,


### PR DESCRIPTION
Implement `EvolvClient.getActiveKeys()`. 
This is an initial implementation of `getActiveKeys()`, it only works properly when `rules` and `keys` are not nested.