### PR TITLE
Refactor out reevaluateContext(). Subscribable active keys.

### DIFF
--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvClientImpl.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvClientImpl.swift
@@ -19,6 +19,8 @@
 import Combine
 
 public final class EvolvClientImpl: EvolvClient {
+    public var activeKeys: [String] { evolvStore.getActiveKeys() }
+    
     private var evolvContext: EvolvContextImpl
     private let options: EvolvClientOptions
     private let evolvAPI: EvolvAPI
@@ -54,7 +56,11 @@ public final class EvolvClientImpl: EvolvClient {
     }
     
     public func getActiveKeys() -> [String] {
-        evolvStore.getActiveKeys()
+        activeKeys
+    }
+    
+    public func reevaluateContext() {
+        evolvStore.reevaluateContext()
     }
     
     public func confirm() {
@@ -66,10 +72,6 @@ public final class EvolvClientImpl: EvolvClient {
     }
     
     public func get(value forKey: String) {
-        return
-    }
-    
-    public func reevaluateContext() {
         return
     }
 }

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvClientImpl.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvClientImpl.swift
@@ -63,7 +63,7 @@ public final class EvolvClientImpl: EvolvClient {
         evolvStore.reevaluateContext()
     }
     
-    public func set(key: String, value: Any, local: Bool) {
+    public func set(key: String, value: Any, local: Bool) -> Bool {
         evolvStore.set(key: key, value: value, local: local)
     }
     

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvClientImpl.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvClientImpl.swift
@@ -19,7 +19,7 @@
 import Combine
 
 public final class EvolvClientImpl: EvolvClient {
-    public var activeKeys: [String] { evolvStore.getActiveKeys() }
+    public var activeKeys: CurrentValueSubject<[String], Never> { evolvStore.activeKeys }
     
     private var evolvContext: EvolvContextImpl
     private let options: EvolvClientOptions
@@ -56,11 +56,15 @@ public final class EvolvClientImpl: EvolvClient {
     }
     
     public func getActiveKeys() -> [String] {
-        activeKeys
+        evolvStore.getActiveKeys()
     }
     
     public func reevaluateContext() {
         evolvStore.reevaluateContext()
+    }
+    
+    public func set(key: String, value: Any, local: Bool) {
+        evolvStore.set(key: key, value: value, local: local)
     }
     
     public func confirm() {

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvContextImpl.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvContextImpl.swift
@@ -36,13 +36,11 @@ public struct EvolvContextImpl: EvolvContext {
         return [:]
     }
     
-    public mutating func set(key: String, value: Any, local: Bool = false) -> [String : Any] {
+    public mutating func set(key: String, value: Any, local: Bool) {
         if local {
             localContext[key] = value
-            return localContext
         } else {
             remoteContext[key] = value
-            return remoteContext
         }
     }
     

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvContextImpl.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvContextImpl.swift
@@ -33,15 +33,20 @@ public struct EvolvContextImpl: EvolvContext {
     }
     
     public func resolve() -> [String: Any] {
-        return [:]
+        return mergedContext
     }
     
-    public mutating func set(key: String, value: Any, local: Bool) {
+    @discardableResult
+    public mutating func set(key: String, value: Any, local: Bool) -> Bool {
+        guard ((local ? localContext[key] : remoteContext[key]) as? String) != (value as? String) else { return false }
+        
         if local {
             localContext[key] = value
         } else {
             remoteContext[key] = value
         }
+        
+        return true
     }
     
     func mergeContext(localContext: [String : Any], remoteContext: [String : Any]) -> [String : Any] {

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvPredicateImpl.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvPredicateImpl.swift
@@ -19,42 +19,42 @@
 
 import Foundation
 
-struct EvolvPredicateImpl {
-    
-    
-    
-    struct FilterOperations {
-        static func contains (a: String, b: String) -> Bool {
-            return a.contains(b)
-        }
-        
-        static func defined (a: String?) -> Bool {
-            return a != nil
-        }
-        
-        static func equal<T: Equatable> (a: T, b: T) -> Bool {
-            return a == b
-        }
-        
-        static func exists (a: String) -> Bool {
-            return a != nil
-        }
-        
-        
-    }
-//    let filterOperations: [String: ()->()]?
-    
-    public func evaluatePredicate (context: EvolvContext, config: EvolvConfig) {
-        
-    }
-}
-
-enum EvaluationResult {
-    
-    static let passed = "passed"
-    static let failed = "failed"
-    static let rejected = "rejected"
-    
-}
-
+//struct EvolvPredicateImpl {
+//    
+//    
+//    
+//    struct FilterOperations {
+//        static func contains (a: String, b: String) -> Bool {
+//            return a.contains(b)
+//        }
+//        
+//        static func defined (a: String?) -> Bool {
+//            return a != nil
+//        }
+//        
+//        static func equal<T: Equatable> (a: T, b: T) -> Bool {
+//            return a == b
+//        }
+//        
+//        static func exists (a: String) -> Bool {
+//            return a != nil
+//        }
+//        
+//        
+//    }
+////    let filterOperations: [String: ()->()]?
+//    
+//    public func evaluatePredicate (context: EvolvContext, config: EvolvConfig) {
+//        
+//    }
+//}
+//
+//enum EvaluationResult {
+//    
+//    static let passed = "passed"
+//    static let failed = "failed"
+//    static let rejected = "rejected"
+//    
+//}
+//
 

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvStoreImpl.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvStoreImpl.swift
@@ -24,7 +24,7 @@ public class EvolvStoreImpl: EvolvStore {
     var evolvConfiguration: Configuration { _evolvConfiguration }
     
     private(set) var evolvAllocations = [Allocation]()
-    private(set) var activeKeys = [String]()
+    private(set) var activeKeys = CurrentValueSubject<[String], Never>([])
     
     private var _evolvConfiguration: Configuration!
     private var evolvContext: EvolvContext
@@ -72,15 +72,21 @@ public class EvolvStoreImpl: EvolvStore {
     }
     
     func isActive(key: String) -> Bool {
-        activeKeys.contains(key)
+        getActiveKeys().contains(key)
     }
     
     func getActiveKeys() -> [String] {
-        activeKeys
+        activeKeys.value
     }
     
     func reevaluateContext() {
-        activeKeys = evolvConfiguration.evaluateActiveKeys(in: evolvContext.mergedContext)
+        activeKeys.send(evolvConfiguration.evaluateActiveKeys(in: evolvContext.mergedContext))
+    }
+    
+    func set(key: String, value: Any, local: Bool) {
+        evolvContext.set(key: key, value: value, local: local)
+        
+        reevaluateContext()
     }
     
     private func update(configRequest: Bool, requestedKeys: [String], value: Any) {
@@ -155,8 +161,6 @@ extension EvolvStoreImpl {
     }
     
     func activeEntryPoints(entryKeys: [String: Any]) -> [String] {
-        var eids: [String] = []
-        
         return []
     }
     

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvStoreImpl.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvStoreImpl.swift
@@ -83,10 +83,14 @@ public class EvolvStoreImpl: EvolvStore {
         activeKeys.send(evolvConfiguration.evaluateActiveKeys(in: evolvContext.mergedContext))
     }
     
-    func set(key: String, value: Any, local: Bool) {
-        evolvContext.set(key: key, value: value, local: local)
+    func set(key: String, value: Any, local: Bool) -> Bool {
+        let isContextChanged = evolvContext.set(key: key, value: value, local: local)
+        
+        guard isContextChanged else { return false }
         
         reevaluateContext()
+        
+        return true
     }
     
     private func update(configRequest: Bool, requestedKeys: [String], value: Any) {

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvStoreImpl.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvStoreImpl.swift
@@ -72,19 +72,11 @@ public class EvolvStoreImpl: EvolvStore {
     }
     
     func isActive(key: String) -> Bool {
-        guard let experimentCollection = evolvConfiguration.experiments.first(where: { $0.experimentKeys.contains { $0.name == key } }),
-              let experiment = experimentCollection.experimentKeys.first(where: { $0.name == key })
-        else { return false }
-        
-        return isActive(experimentCollection: experimentCollection) && isActive(experiment: experiment)
+        getActiveKeys().contains(key)
     }
     
-    // TODO: Doesn't work correctly with nested rules and keys.
     func getActiveKeys() -> [String] {
-        evolvConfiguration.experiments
-            .flatMap { $0.experimentKeys }
-            .map { $0.name }
-            .filter { isActive(key: $0) }
+        evolvConfiguration.getActiveKeys(in: evolvContext.mergedContext)
     }
     
     private func update(configRequest: Bool, requestedKeys: [String], value: Any) {

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Data Model/Configuration.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Data Model/Configuration.swift
@@ -266,21 +266,21 @@ public struct ExperimentPredicate: Codable, Equatable {
 }
 
 extension Configuration {
-    func getActiveKeys(in context: [String : Any]) -> [String] {
+    func evaluateActiveKeys(in context: [String : Any]) -> [String] {
         experiments.flatMap {
-            getActiveKeys(from: $0, in: context)
+            evaluateActiveKeys(from: $0, in: context)
         }
     }
     
-    private func getActiveKeys(from experiment: Experiment, in context: [String : Any]) -> [String] {
+    private func evaluateActiveKeys(from experiment: Experiment, in context: [String : Any]) -> [String] {
         guard experiment.isActive(in: context) else { return [] }
         
         return experiment.experimentKeys.flatMap {
-            getActiveKeys(from: $0, in: context)
+            evaluateActiveKeys(from: $0, in: context)
         }
     }
     
-    private func getActiveKeys(from experimentKey: ExperimentKey, in context: [String : Any]) -> [String] {
+    private func evaluateActiveKeys(from experimentKey: ExperimentKey, in context: [String : Any]) -> [String] {
         var keys = [String]()
         
         guard experimentKey.isActive(in: context) else { return keys }
@@ -288,7 +288,7 @@ extension Configuration {
         keys.append(experimentKey.keyPath.keyPathString)
         
         return experimentKey.subKeys.flatMap {
-            getActiveKeys(from: $0, in: context)
+            evaluateActiveKeys(from: $0, in: context)
         } + keys
     }
 }

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Protocols/EvolvClient.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Protocols/EvolvClient.swift
@@ -46,6 +46,15 @@ public protocol EvolvClient {
     /// - Parameter forKey: The identifier of the event.
     func get(value forKey: String)
     
+    /// Sets a value in the current context.
+    /// - Note: This will cause the effective genome to be recomputed.
+    /// - Parameter key: The key to associate the value to.
+    /// - Parameter value: The value to associate with the key.
+    /// - Parameter local: If true, the value will only be added to the localContext.
+    /// - Returns: True if the context was updated. False if the the context already had the provided value set for this key.
+    @discardableResult
+    func set(key: String, value: Any, local: Bool) -> Bool
+    
     /// Reevaluates the current context.
     func reevaluateContext()
     

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Protocols/EvolvClient.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Protocols/EvolvClient.swift
@@ -20,7 +20,7 @@ import Combine
 
 public protocol EvolvClient {
     /// Active keys evaluated in the current Evolv context.
-    var activeKeys: [String] { get }
+    var activeKeys: CurrentValueSubject<[String], Never> { get }
     
     /// Initialises EvolvClient with desired EvolvClientOptions
     /// - Parameter options: Provide desired options for the EvolvClient.

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Protocols/EvolvClient.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Protocols/EvolvClient.swift
@@ -19,6 +19,8 @@
 import Combine
 
 public protocol EvolvClient {
+    /// Active keys evaluated in the current Evolv context.
+    var activeKeys: [String] { get }
     
     /// Initialises EvolvClient with desired EvolvClientOptions
     /// - Parameter options: Provide desired options for the EvolvClient.

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Protocols/EvolvContext.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Protocols/EvolvContext.swift
@@ -58,7 +58,7 @@ internal protocol EvolvContext {
     /// - Parameter key: The key to associate the value to.
     /// - Parameter value: The value to associate with the key.
     /// - Parameter local: If true, the value will only be added to the localContext.
-    mutating func set(key: String, value: Any, local: Bool) -> [String: Any]
+    mutating func set(key: String, value: Any, local: Bool)
     
 //    /// Merge the specified object into the current context.
 //    /// Note: This will cause the effective genome to be recomputed.

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Protocols/EvolvContext.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Protocols/EvolvContext.swift
@@ -54,11 +54,13 @@ internal protocol EvolvContext {
     func resolve() -> [String: Any]
     
     /// Sets a value in the current context.
-    /// Note: This will cause the effective genome to be recomputed.
+    /// - Note: This will cause the effective genome to be recomputed.
     /// - Parameter key: The key to associate the value to.
     /// - Parameter value: The value to associate with the key.
     /// - Parameter local: If true, the value will only be added to the localContext.
-    mutating func set(key: String, value: Any, local: Bool)
+    /// - Returns: True if the context was updated. False if the the context already had the provided value set for this key.
+    @discardableResult
+    mutating func set(key: String, value: Any, local: Bool) -> Bool
     
 //    /// Merge the specified object into the current context.
 //    /// Note: This will cause the effective genome to be recomputed.

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Protocols/EvolvStore.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Protocols/EvolvStore.swift
@@ -31,5 +31,6 @@ protocol EvolvStore {
     
     func reevaluateContext()
     
-    func set(key: String, value: Any, local: Bool)
+    @discardableResult
+    func set(key: String, value: Any, local: Bool) -> Bool
 }

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Protocols/EvolvStore.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Protocols/EvolvStore.swift
@@ -27,4 +27,6 @@ protocol EvolvStore {
     func isActive(key: String) -> Bool
     
     func getActiveKeys() -> [String]
+    
+    func reevaluateContext()
 }

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Protocols/EvolvStore.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Protocols/EvolvStore.swift
@@ -16,11 +16,12 @@
 //  limitations under the License.
 //
 
-
-import Foundation
+import Combine
 
 /// A type that can store and retrieve participant's allocations.
 protocol EvolvStore {
+    var activeKeys: CurrentValueSubject<[String], Never> { get }
+    
     var evolvAllocations: [Allocation] { get }
     var evolvConfiguration: Configuration { get }
     
@@ -29,4 +30,6 @@ protocol EvolvStore {
     func getActiveKeys() -> [String]
     
     func reevaluateContext()
+    
+    func set(key: String, value: Any, local: Bool)
 }

--- a/EvolvSwiftSDK/EvolvSwiftSDKTests/Common-Tests/EvolvStoreNewTests.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDKTests/Common-Tests/EvolvStoreNewTests.swift
@@ -101,8 +101,8 @@ class EvolvStoreNewTests: XCTestCase {
         let evolvStore = initializeEvolvStore(with: context)
         let activeKeys = evolvStore.getActiveKeys()
         
-        XCTAssert(activeKeys.contains("next"))
-        XCTAssertEqual(activeKeys.count, 1)
+        XCTAssert(activeKeys.contains("next.layout"))
+        XCTAssertEqual(activeKeys.count, 2)
     }
     
     func testGetActiveKeysSubKeysAreActive() {

--- a/EvolvSwiftSDK/EvolvSwiftSDKTests/Common-Tests/EvolvStoreTest.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDKTests/Common-Tests/EvolvStoreTest.swift
@@ -41,13 +41,13 @@ class EvolvStoreTest: XCTestCase {
         let remoteContext: [String: Any] = ["test_key" : "test_value"]
         let localContext: [String: Any] = [:]
         
-        var context = EvolvContextImpl(remoteContext: remoteContext, localContext: localContext)
+        var evolvContext = EvolvContextImpl(remoteContext: remoteContext, localContext: localContext)
         
-        let evolvContext = context.set(key: "new_key", value: "new_value")
+        evolvContext.set(key: "new_key", value: "new_value", local: false)
         
         XCTAssertNotNil(evolvContext)
-        XCTAssertEqual(evolvContext["new_key"] as? String, "new_value")
-        XCTAssertEqual(evolvContext["test_key"] as? String, "test_value")
+        XCTAssertEqual(evolvContext.remoteContext["new_key"] as? String, "new_value")
+        XCTAssertEqual(evolvContext.remoteContext["test_key"] as? String, "test_value")
     }
     
     func testContextIsNotEmpty() {
@@ -56,8 +56,8 @@ class EvolvStoreTest: XCTestCase {
         
         let context = EvolvContextImpl(remoteContext: remoteContext, localContext: localContext)
         
-        XCTAssertEqual(remoteContext.isEmpty, false)
-        XCTAssertEqual(localContext.isEmpty, false)
+        XCTAssertEqual(context.remoteContext.isEmpty, false)
+        XCTAssertEqual(context.localContext.isEmpty, false)
     }
     
     func testMergeContext() {
@@ -81,7 +81,7 @@ class EvolvStoreTest: XCTestCase {
         
         let rules = [Rule(field: "Age", ruleOperator: Rule.RuleOperator(rawValue: "equal")!, value: "26")]
         
-        let experimentPredicate = ExperimentPredicate(id: 174, combinator: .and, rules: rules)
+        let _ = ExperimentPredicate(id: 174, combinator: .and, rules: rules)
         
 //        let experiments = ExperimentCollection(predicate: experimentPredicate, id: "47d857cd5e", paused: false, experiments: [])
         
@@ -95,7 +95,7 @@ class EvolvStoreTest: XCTestCase {
 //                                            ]
 //                                        ]
         
-        var jsonData = """
+        let jsonData = """
                     {
                         "web": {},
                         "_predicate": {},


### PR DESCRIPTION
- Separate reevaluateContext() from getActiveKeys(). Active keys are now computed only on context change instead of every call to getActiveKeys();
- Make active keys subscribable to changes.