### PR TITLE
refactor out EvolvClientImpl

### DIFF
--- a/EvolvAppExample/EvolvAppExample/ViewController.swift
+++ b/EvolvAppExample/EvolvAppExample/ViewController.swift
@@ -29,7 +29,7 @@ class ViewController: UIViewController {
         // MARK: - Initialise EvolvClient.
         // Populate it with desired options.
         // Store the received object to work with it later.
-        EvolvClientImpl.initialize(options: options)
+        EvolvClientFactory(with: options).initializeClient()
             .sink(receiveCompletion: { publisherResult in
                 switch publisherResult {
                 case .finished:

--- a/EvolvSwiftSDK/EvolvSwiftSDK.xcodeproj/project.pbxproj
+++ b/EvolvSwiftSDK/EvolvSwiftSDK.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		5907D53126F611EF007B3A3F /* Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5907D53026F611EF007B3A3F /* Combine.swift */; };
 		5907D53326F61944007B3A3F /* XCTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5907D53226F61944007B3A3F /* XCTest.swift */; };
 		5924905426CD20060018CFF9 /* Combine+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5924905326CD20060018CFF9 /* Combine+Extensions.swift */; };
+		592B239327147CB60080DF39 /* EvolvClientFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 592B239227147CB60080DF39 /* EvolvClientFactory.swift */; };
 		595E202E26F8BA5400D2D138 /* allocations_single.json in Resources */ = {isa = PBXBuildFile; fileRef = 595E202D26F8BA5400D2D138 /* allocations_single.json */; };
 		595FABF926CE72640023A1D9 /* EvolvStoreNewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 595FABF826CE72640023A1D9 /* EvolvStoreNewTests.swift */; };
 		595FABFB26CE73910023A1D9 /* EvolvAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 595FABFA26CE73910023A1D9 /* EvolvAPI.swift */; };
@@ -27,8 +28,6 @@
 		59C935BE270DB598006CFD8C /* ExcludedAllocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C935BD270DB598006CFD8C /* ExcludedAllocation.swift */; };
 		59C935C0270DB877006CFD8C /* AllocationContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59C935BF270DB877006CFD8C /* AllocationContainer.swift */; };
 		59C935C4270EF6C8006CFD8C /* allocations_excluded.json in Resources */ = {isa = PBXBuildFile; fileRef = 59C935C3270EF6C8006CFD8C /* allocations_excluded.json */; };
-		59D1F35926E0EA73005534BC /* EvolvContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59D1F35826E0EA73005534BC /* EvolvContext.swift */; };
-		59D1F35B26E0EAD2005534BC /* EvolvContextImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59D1F35A26E0EAD2005534BC /* EvolvContextImpl.swift */; };
 		59E5B7522701FDB300FC1DCF /* EvolvBeacon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59E5B74E2701ED4700FC1DCF /* EvolvBeacon.swift */; };
 		59E5B7532701FDE200FC1DCF /* AnyEncodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59E5B7502701EEB600FC1DCF /* AnyEncodable.swift */; };
 		59E5B7562701FF4800FC1DCF /* EvolvBeaconMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59E5B7542701FF2900FC1DCF /* EvolvBeaconMessage.swift */; };
@@ -82,6 +81,7 @@
 		5907D53026F611EF007B3A3F /* Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Combine.swift; sourceTree = "<group>"; };
 		5907D53226F61944007B3A3F /* XCTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XCTest.swift; sourceTree = "<group>"; };
 		5924905326CD20060018CFF9 /* Combine+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Combine+Extensions.swift"; sourceTree = "<group>"; };
+		592B239227147CB60080DF39 /* EvolvClientFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvolvClientFactory.swift; sourceTree = "<group>"; };
 		595E202D26F8BA5400D2D138 /* allocations_single.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = allocations_single.json; sourceTree = "<group>"; };
 		595FABF826CE72640023A1D9 /* EvolvStoreNewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvolvStoreNewTests.swift; sourceTree = "<group>"; };
 		595FABFA26CE73910023A1D9 /* EvolvAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvolvAPI.swift; sourceTree = "<group>"; };
@@ -97,8 +97,6 @@
 		59C935BD270DB598006CFD8C /* ExcludedAllocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExcludedAllocation.swift; sourceTree = "<group>"; };
 		59C935BF270DB877006CFD8C /* AllocationContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllocationContainer.swift; sourceTree = "<group>"; };
 		59C935C3270EF6C8006CFD8C /* allocations_excluded.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = allocations_excluded.json; sourceTree = "<group>"; };
-		59D1F35826E0EA73005534BC /* EvolvContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvolvContext.swift; sourceTree = "<group>"; };
-		59D1F35A26E0EAD2005534BC /* EvolvContextImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvolvContextImpl.swift; sourceTree = "<group>"; };
 		59E5B74E2701ED4700FC1DCF /* EvolvBeacon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvolvBeacon.swift; sourceTree = "<group>"; };
 		59E5B7502701EEB600FC1DCF /* AnyEncodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyEncodable.swift; sourceTree = "<group>"; };
 		59E5B7542701FF2900FC1DCF /* EvolvBeaconMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvolvBeaconMessage.swift; sourceTree = "<group>"; };
@@ -257,6 +255,7 @@
 				59B548FE26FC8E5F00E0222B /* EvolvClientOptions.swift */,
 				59E5B74E2701ED4700FC1DCF /* EvolvBeacon.swift */,
 				59E5B7542701FF2900FC1DCF /* EvolvBeaconMessage.swift */,
+				592B239227147CB60080DF39 /* EvolvClientFactory.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -503,6 +502,7 @@
 				59B548FB26FB6B8500E0222B /* EvolvCustomEvent.swift in Sources */,
 				8D9C610E266F88640011EC8A /* EvolvHttpClient.swift in Sources */,
 				8D9C6101266F88640011EC8A /* EvolvStore.swift in Sources */,
+				592B239327147CB60080DF39 /* EvolvClientFactory.swift in Sources */,
 				8DE7B38026710E82003E76A7 /* EvolvClientImpl.swift in Sources */,
 				8D9C60FF266F88640011EC8A /* EvolvStoreImpl.swift in Sources */,
 				59B548FD26FB7B5600E0222B /* EvolvCustomEventForSubmission.swift in Sources */,

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvClientFactory.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvClientFactory.swift
@@ -1,0 +1,38 @@
+//
+//  EvolvClientFactory.swift
+//
+//  Copyright (c) 2021 Evolv Technology Solutions
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+import Combine
+
+/// Factory for creating an `EvolvClient` instance.
+public final class EvolvClientFactory {
+    /// Provided client options.
+    public let options: EvolvClientOptions
+    
+    /// Initializes factory with provided options.
+    /// Stores configuration options for EvolvClient ready for initialization.
+    /// - Parameter options: Provide desired options for the EvolvClient.
+    public init(with options: EvolvClientOptions) {
+        self.options = options
+    }
+    
+    /// Initializes EvolvClient with provided options.
+    /// - Returns: Publisher for the EvolvClient object.
+    public func initializeClient() -> AnyPublisher<EvolvClient, Error> {
+        return EvolvClientImpl.initialize(options: options)
+    }
+}

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvClientImpl.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvClientImpl.swift
@@ -18,7 +18,7 @@
 
 import Combine
 
-public final class EvolvClientImpl: EvolvClient {
+final class EvolvClientImpl: EvolvClient {
     private let scope: AnyHashable
     
     public var activeKeys: AnyPublisher<Set<String>, Never> { evolvStore.activeKeys.eraseToAnyPublisher() }

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Protocols/EvolvClient.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Protocols/EvolvClient.swift
@@ -26,11 +26,6 @@ public protocol EvolvClient {
     /// Active variant keys evaluated in the current Evolv context.
     var activeVariantKeys: AnyPublisher<Set<String>, Never> { get }
     
-    /// Initialises EvolvClient with desired EvolvClientOptions
-    /// - Parameter options: Provide desired options for the EvolvClient.
-    /// - Returns: Publisher for the EvolvClient object.
-    static func initialize(options: EvolvClientOptions) -> AnyPublisher<EvolvClient, Error>
-    
     /// Sends a confirmed event to Evolv.
     ///
     /// Method produces a confirmed event which confirms the participant's


### PR DESCRIPTION
Hide EvolvClient protocol implementation from the SDK user.