### PR TITLE
Fix/ap 1656 predicates

### DIFF
--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvClientImpl.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvClientImpl.swift
@@ -73,56 +73,52 @@ final class EvolvClientImpl: EvolvClient {
     }
     
     private func waitForOnInitialization() {
-        if options.analytics {
-            WaitForIt.shared.waitFor(scope: scope, it: CONTEXT_INITIALIZED) { [weak self] payload in
-                guard let self = self,
-                      let type = payload["it"] as? String
-                else { return }
-                
-                struct Empty: Encodable {}
-                self.contextBeacon.emit(type: type, payload: Empty())
-            }
+        WaitForIt.shared.waitFor(scope: scope, it: CONTEXT_INITIALIZED) { [weak self] payload in
+            guard let self = self,
+                  let type = payload["it"] as? String
+            else { return }
             
-            WaitForIt.shared.waitFor(scope: scope, it: CONTEXT_VALUE_ADDED) { [weak self] payload in
-                guard let self = self,
-                      payload["local"] as? Bool == false,
-                      let type = payload["it"] as? String,
-                      let key = payload["key"] as? String,
-                      let value = payload["value"] as? Encodable
-                else { return }
-                
-                self.contextBeacon.emit(type: type, key: key, value: value)
-            }
+            struct Empty: Encodable {}
+            self.contextBeacon.emit(type: type, payload: Empty())
+        }
+        
+        WaitForIt.shared.waitFor(scope: scope, it: CONTEXT_VALUE_ADDED) { [weak self] payload in
+            guard let self = self,
+                  payload["local"] as? Bool == false,
+                  let type = payload["it"] as? String,
+                  let key = payload["key"] as? String,
+                  let value = payload["value"] as? Encodable
+            else { return }
             
-            WaitForIt.shared.waitFor(scope: scope, it: CONTEXT_VALUE_CHANGED) { [weak self] payload in
-                guard let self = self,
-                      payload["local"] as? Bool == false,
-                      let type = payload["it"] as? String,
-                      let key = payload["key"] as? String,
-                      let value = payload["value"] as? Encodable
-                else { return }
-                
-                self.contextBeacon.emit(type: type, key: key, value: value)
-            }
+            self.contextBeacon.emit(type: type, key: key, value: value)
+        }
+        
+        WaitForIt.shared.waitFor(scope: scope, it: CONTEXT_VALUE_CHANGED) { [weak self] payload in
+            guard let self = self,
+                  payload["local"] as? Bool == false,
+                  let type = payload["it"] as? String,
+                  let key = payload["key"] as? String,
+                  let value = payload["value"] as? Encodable
+            else { return }
             
-            WaitForIt.shared.waitFor(scope: scope, it: CONTEXT_VALUE_REMOVED) { [weak self] payload in
-                guard let self = self,
-                      payload["remote"] as? Bool == true,
-                      let type = payload["it"] as? String,
-                      let key = payload["key"] as? String
-                else { return }
-                
-                self.contextBeacon.emit(type: type, key: key, value: nil)
-            }
+            self.contextBeacon.emit(type: type, key: key, value: value)
+        }
+        
+        WaitForIt.shared.waitFor(scope: scope, it: CONTEXT_VALUE_REMOVED) { [weak self] payload in
+            guard let self = self,
+                  payload["remote"] as? Bool == true,
+                  let type = payload["it"] as? String,
+                  let key = payload["key"] as? String
+            else { return }
+            
+            self.contextBeacon.emit(type: type, key: key, value: nil)
         }
     }
     
     private func waitForAfterInitialization() {
-        if options.autoConfirm {
-            self.confirm()
-            WaitForIt.shared.waitFor(scope: scope, it: REQUEST_FAILED) { payload in
-                // self?.contaminate(details: , allExperiments: )
-            }
+        self.confirm()
+        WaitForIt.shared.waitFor(scope: scope, it: REQUEST_FAILED) { payload in
+            // self?.contaminate(details: , allExperiments: )
         }
         
         WaitForIt.shared.emit(scope: scope, it: EvolvClient_INITIALIZED, ["options":options])

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvClientOptions.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Core/EvolvClientOptions.swift
@@ -23,33 +23,27 @@ public struct EvolvClientOptions {
     public let evolvDomain: String
     public let participantID: String
     public let environmentId: String
-    public let autoConfirm: Bool
-    public let analytics: Bool
     public let blockTransmit: Bool
     public let remoteContext: [String : String]
     public let localContext: [String : String]
     let beacon: EvolvBeacon?
     
-    public init(apiVersion: Int = 1, evolvDomain: String = "participants-stg.evolv.ai", participantID: String, environmentId: String, autoConfirm: Bool, analytics: Bool, remoteContext: [String : String] = [:], localContext: [String : String] = [:], blockTransmit: Bool = false) {
+    public init(apiVersion: Int = 1, evolvDomain: String = "participants-stg.evolv.ai", participantID: String, environmentId: String, remoteContext: [String : String] = [:], localContext: [String : String] = [:], blockTransmit: Bool = false) {
         self.apiVersion = apiVersion
         self.evolvDomain = evolvDomain
         self.participantID = participantID
         self.environmentId = environmentId
-        self.autoConfirm = autoConfirm
-        self.analytics = analytics
         self.remoteContext = remoteContext
         self.localContext = localContext
         self.blockTransmit = blockTransmit
         self.beacon = nil
     }
     
-    init(apiVersion: Int = 1, evolvDomain: String = "participants-stg.evolv.ai", participantID: String = "80658403_1629111253538", environmentId: String = "4a64e0b2ab", autoConfirm: Bool = true, analytics: Bool = false, remoteContext: [String : String] = [:], localContext: [String : String] = [:], blockTransmit: Bool = false, beacon: EvolvBeacon) {
+    init(apiVersion: Int = 1, evolvDomain: String = "participants-stg.evolv.ai", participantID: String = "80658403_1629111253538", environmentId: String = "4a64e0b2ab", remoteContext: [String : String] = [:], localContext: [String : String] = [:], blockTransmit: Bool = false, beacon: EvolvBeacon) {
         self.apiVersion = apiVersion
         self.evolvDomain = evolvDomain
         self.participantID = participantID
         self.environmentId = environmentId
-        self.autoConfirm = autoConfirm
-        self.analytics = analytics
         self.remoteContext = remoteContext
         self.localContext = localContext
         self.blockTransmit = blockTransmit

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Data Model/Configuration.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Data Model/Configuration.swift
@@ -195,6 +195,7 @@ struct Rule: Codable, Equatable, Hashable {
     
     enum RuleOperator: String, Codable, Equatable {
         case equal = "equal"
+        case looseEqual = "loose_equal"
         case notEqual = "not_equal"
         case contains = "contains"
         case notContains = "not_contains"
@@ -206,6 +207,8 @@ struct Rule: Codable, Equatable, Hashable {
     func evaluateRule(value userValue: String?) -> Bool {
         switch self.ruleOperator {
         case .equal:
+            return self.value == userValue
+        case .looseEqual:
             return self.value == userValue
         case .notEqual:
             return self.value != userValue
@@ -230,7 +233,6 @@ struct CompoundRule: Decodable, Equatable, Hashable {
         case or
     }
     
-    let id: Int?
     let combinator: Combinator
     let rules: [EvolvQuery]
     

--- a/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Data Model/Configuration.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDK/Sources/Data Model/Configuration.swift
@@ -103,7 +103,11 @@ struct Experiment: Decodable, Equatable {
     
     func getKey(at path: ExperimentKey.ExperimentKeyPath) -> ExperimentKey? {
         func getKey(at path: ExperimentKey.ExperimentKeyPath, from key: ExperimentKey) -> ExperimentKey? {
-            key.subKeys.first { $0.keyPath == path } ??
+            if (key.keyPath == path) {
+                return key;
+            }
+            
+            return key.subKeys.first { $0.keyPath == path } ??
             key.subKeys.first { getKey(at: path, from: $0) != nil }
         }
         
@@ -202,6 +206,15 @@ struct Rule: Codable, Equatable, Hashable {
         case exists
         case regexMatch = "regex_match"
         case notRegexMatch = "not_regex_match"
+        /* TODO add in support for
+         greater_than
+        greater_than_or_equal_to
+        is_true
+        is_false
+        not_exists
+        less_than
+        less_than_or_equal_to
+        loose_not_equal*/
     }
     
     func evaluateRule(value userValue: String?) -> Bool {

--- a/EvolvSwiftSDK/EvolvSwiftSDKTests/Common-Tests/EvolvClientTests.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDKTests/Common-Tests/EvolvClientTests.swift
@@ -370,9 +370,9 @@ class EvolvClientTests: XCTestCase {
 extension EvolvClientTests {
     func testDataCallContextIsInitialized() {
         let _ = EvolvClientImpl(options: options, evolvAPI: evolvAPI, scope: scope).initialize().wait()
-        
+        struct Empty: Encodable {}
         let actualSubmittedData = evolvAPI.submittedData.first
-        let expectedSubmittedDatta = EvolvBeaconMessage(uid: options.participantID, messages: [.init(type: CONTEXT_INITIALIZED, payload: AnyEncodable([AnyHashable : Any]().encoded()))])
+        let expectedSubmittedDatta = EvolvBeaconMessage(uid: options.participantID, messages: [.init(type: CONTEXT_INITIALIZED, payload: AnyEncodable(Empty()))])
         
         XCTAssertEqual(actualSubmittedData, expectedSubmittedDatta)
     }

--- a/EvolvSwiftSDK/EvolvSwiftSDKTests/Common-Tests/EvolvClientTests.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDKTests/Common-Tests/EvolvClientTests.swift
@@ -40,7 +40,7 @@ class EvolvClientTests: XCTestCase {
         evolvAPI = EvolvAPIMock(evolvConfiguration: configuration, evolvAllocations: allocations)
         evolvBeacon = EvolvBeaconMock(endPoint: evolvAPI.submit(data:), uid: "80658403_1629111253538", blockTransmit: false)
         
-        options = EvolvClientOptions(evolvDomain: "participants-stg.evolv.ai", participantID: "80658403_1629111253538", environmentId: "4a64e0b2ab", analytics: true, beacon: evolvBeacon)
+        options = EvolvClientOptions(evolvDomain: "participants-stg.evolv.ai", participantID: "80658403_1629111253538", environmentId: "4a64e0b2ab", beacon: evolvBeacon)
     }
 
     override func tearDownWithError() throws {
@@ -54,7 +54,7 @@ class EvolvClientTests: XCTestCase {
     }
     
     // MARK: - Confirm
-    func testEvolvClientConfirm() {
+    func testEvolvClientConfirmEntryWithChildNodes() {
         let context = EvolvContextContainerImpl(remoteContextUserInfo: ["location" : "UA",
                                                                         "view" : "home",
                                                                         "signedin" : "yes"],
@@ -67,6 +67,21 @@ class EvolvClientTests: XCTestCase {
         
         let actualSubmittedEvents = evolvAPI.submittedEvents as! [EvolvConfirmation]
         let expectedSubmittedEvents = [EvolvConfirmation(cid: "5fa0fd38aae6:47d857cd5e", uid: "C51EEAFC-724D-47F7-B99A-F3494357F164", eid: "ff01d1516c", timeStamp: actualSubmittedEvents[0].timeStamp)]
+        
+        XCTAssertEqual(expectedSubmittedEvents, actualSubmittedEvents)
+    }
+    
+    func testEvolvClientConfirmEntryWithoutChildNodes() {
+        let context = EvolvContextContainerImpl(remoteContextUserInfo: ["noChildren" : "true"],
+                                                localContextUserInfo: [:], scope: scope)
+        
+        let store = EvolvStoreImpl.initialize(evolvContext: context, evolvAPI: evolvAPI, scope: scope).wait()
+        let client = EvolvClientImpl(options: options, evolvStore: store, evolvAPI: evolvAPI, scope: scope)
+        
+        client.confirm()
+        
+        let actualSubmittedEvents = evolvAPI.submittedEvents as! [EvolvConfirmation]
+        let expectedSubmittedEvents = [EvolvConfirmation(cid: "5fa0fd38aae6:1234567890", uid: "A", eid: "1234567890", timeStamp: actualSubmittedEvents[0].timeStamp)]
         
         XCTAssertEqual(expectedSubmittedEvents, actualSubmittedEvents)
     }
@@ -391,7 +406,7 @@ extension EvolvClientTests {
     func testDataCallUserInfoIsAdded() {
         let remoteContext = ["device" : "mobile",
                              "location" : "UA"]
-        let options = EvolvClientOptions(evolvDomain: "participants-stg.evolv.ai", participantID: "80658403_1629111253538", environmentId: "4a64e0b2ab", analytics: true, remoteContext: remoteContext, beacon: evolvBeacon)
+        let options = EvolvClientOptions(evolvDomain: "participants-stg.evolv.ai", participantID: "80658403_1629111253538", environmentId: "4a64e0b2ab", remoteContext: remoteContext, beacon: evolvBeacon)
         let _ = EvolvClientImpl(options: options, evolvAPI: evolvAPI, scope: scope).initialize().wait()
         
         let actualSubmittedData = evolvAPI.submittedData.set()
@@ -405,7 +420,7 @@ extension EvolvClientTests {
     
     func testDataCallUserInfoIsChanged() {
         let remoteContext = ["location" : "UA"]
-        let options = EvolvClientOptions(evolvDomain: "participants-stg.evolv.ai", participantID: "80658403_1629111253538", environmentId: "4a64e0b2ab", analytics: true, remoteContext: remoteContext, beacon: evolvBeacon)
+        let options = EvolvClientOptions(evolvDomain: "participants-stg.evolv.ai", participantID: "80658403_1629111253538", environmentId: "4a64e0b2ab", remoteContext: remoteContext, beacon: evolvBeacon)
         let client = EvolvClientImpl(options: options, evolvAPI: evolvAPI, scope: scope).initialize().wait()
         
         _ = client.set(key: "location", value: "US", local: false)
@@ -423,7 +438,7 @@ extension EvolvClientTests {
         let remoteContext = ["location":"UA",
                              "view":"home",
                              "name":"Alex"]
-        let options = EvolvClientOptions(evolvDomain: "participants-stg.evolv.ai", participantID: "80658403_1629111253538", environmentId: "4a64e0b2ab", analytics: true, remoteContext: remoteContext, beacon: evolvBeacon)
+        let options = EvolvClientOptions(evolvDomain: "participants-stg.evolv.ai", participantID: "80658403_1629111253538", environmentId: "4a64e0b2ab", remoteContext: remoteContext, beacon: evolvBeacon)
         let client = EvolvClientImpl(options: options, evolvAPI: evolvAPI, scope: scope).initialize().wait()
         
         _ = client.set(key: "view", value: "next", local: false)
@@ -441,7 +456,7 @@ extension EvolvClientTests {
 // MARK: - On listeners
 extension EvolvClientTests {
     func testOnContextValueAdded() {
-        let options = EvolvClientOptions(evolvDomain: "participants-stg.evolv.ai", participantID: "80658403_1629111253538", environmentId: "4a64e0b2ab", analytics: true, remoteContext: [:], beacon: evolvBeacon)
+        let options = EvolvClientOptions(evolvDomain: "participants-stg.evolv.ai", participantID: "80658403_1629111253538", environmentId: "4a64e0b2ab", remoteContext: [:], beacon: evolvBeacon)
         let client = EvolvClientImpl(options: options, evolvAPI: evolvAPI, scope: scope).initialize().wait()
         
         struct Value: Equatable, Hashable {
@@ -462,7 +477,7 @@ extension EvolvClientTests {
     }
     
     func testOnSameContextValueChangedForRemoteAndLocal() {
-        let options = EvolvClientOptions(evolvDomain: "participants-stg.evolv.ai", participantID: "80658403_1629111253538", environmentId: "4a64e0b2ab", analytics: true, remoteContext: [:], beacon: evolvBeacon)
+        let options = EvolvClientOptions(evolvDomain: "participants-stg.evolv.ai", participantID: "80658403_1629111253538", environmentId: "4a64e0b2ab", remoteContext: [:], beacon: evolvBeacon)
         let client = EvolvClientImpl(options: options, evolvAPI: evolvAPI, scope: scope).initialize().wait()
         
         struct Value: Equatable, Hashable {
@@ -488,7 +503,7 @@ extension EvolvClientTests {
     }
     
     func testOnContextValueRemoved() {
-        let options = EvolvClientOptions(evolvDomain: "participants-stg.evolv.ai", participantID: "80658403_1629111253538", environmentId: "4a64e0b2ab", analytics: true, remoteContext: [:], beacon: evolvBeacon)
+        let options = EvolvClientOptions(evolvDomain: "participants-stg.evolv.ai", participantID: "80658403_1629111253538", environmentId: "4a64e0b2ab", remoteContext: [:], beacon: evolvBeacon)
         let client = EvolvClientImpl(options: options, evolvAPI: evolvAPI, scope: scope).initialize().wait()
         
         struct Value: Equatable, Hashable {
@@ -516,7 +531,7 @@ extension EvolvClientTests {
     }
     
     func testOnceContextValueChanged() {
-        let options = EvolvClientOptions(evolvDomain: "participants-stg.evolv.ai", participantID: "80658403_1629111253538", environmentId: "4a64e0b2ab", analytics: true, remoteContext: [:], beacon: evolvBeacon)
+        let options = EvolvClientOptions(evolvDomain: "participants-stg.evolv.ai", participantID: "80658403_1629111253538", environmentId: "4a64e0b2ab", remoteContext: [:], beacon: evolvBeacon)
         let client = EvolvClientImpl(options: options, evolvAPI: evolvAPI, scope: scope).initialize().wait()
         
         struct Value: Equatable, Hashable {
@@ -541,7 +556,7 @@ extension EvolvClientTests {
     }
     
     func testOnEmitEventWithMetadata() {
-        let options = EvolvClientOptions(evolvDomain: "participants-stg.evolv.ai", participantID: "80658403_1629111253538", environmentId: "4a64e0b2ab", analytics: true, remoteContext: [:], beacon: evolvBeacon)
+        let options = EvolvClientOptions(evolvDomain: "participants-stg.evolv.ai", participantID: "80658403_1629111253538", environmentId: "4a64e0b2ab", remoteContext: [:], beacon: evolvBeacon)
         let client = EvolvClientImpl(options: options, evolvAPI: evolvAPI, scope: scope).initialize().wait()
         
         struct Metadata: Encodable, Equatable {

--- a/EvolvSwiftSDK/EvolvSwiftSDKTests/DataModel-Tests/ConfigurationDataTest.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDKTests/DataModel-Tests/ConfigurationDataTest.swift
@@ -40,7 +40,6 @@ class ConfigurationDataTest: XCTestCase {
     func testCanParseConfigurationJSONFile() throws {
         XCTAssertEqual("desktop", configurationData.client.device)
         XCTAssertEqual("BY", configurationData.client.location)
-        XCTAssertEqual(156, configurationData.experiments[1].predicate?.id)
         XCTAssertEqual("ff01d1516c", configurationData.experiments[0].id)
         XCTAssertEqual(false, configurationData.experiments[0].paused)
     }
@@ -74,9 +73,9 @@ class ConfigurationDataTest: XCTestCase {
           ]
         }
         """.data(using: .utf8)!
-        let expectedDecodedPredicate = CompoundRule(id: 156, combinator: .and, rules: [
+        let expectedDecodedPredicate = CompoundRule(combinator: .and, rules: [
                                                         .rule(.init(field: "location", ruleOperator: .equal, value: "UA")),
-                                                        .compoundRule(.init(id: nil, combinator: .or, rules: [
+                                                        .compoundRule(.init(combinator: .or, rules: [
                                                                                 .rule(.init(field: "location", ruleOperator: .equal, value: "UA")),
                                                                                 .rule(.init(field: "Student", ruleOperator: .contains, value: "High_school"))]))])
         
@@ -125,12 +124,10 @@ class ConfigurationDataTest: XCTestCase {
         }
         """.data(using: .utf8)!
         
-        let expectedPredicate = MockRulesContainer(_predicate: .init(id: nil,
-                                                                     combinator: .or,
+        let expectedPredicate = MockRulesContainer(_predicate: .init(combinator: .or,
                                                                      rules: [
                                                                         .rule(.init(field: "device", ruleOperator: .equal, value: "mobile")),
-                                                                        .compoundRule(.init(id: nil,
-                                                                                            combinator: .or,
+                                                                        .compoundRule(.init(combinator: .or,
                                                                                             rules: [
                                                                                                 .rule(.init(field: "location",
                                                                                                             ruleOperator: .equal,
@@ -229,14 +226,14 @@ class ConfigurationDataTest: XCTestCase {
         }
         """.data(using: .utf8)!
         
-        let experiment = Experiment(predicate: .init(id: nil, combinator: .and, rules: [
+        let experiment = Experiment(predicate: .init(combinator: .and, rules: [
                                                         .rule(.init(field: "color", ruleOperator: .equal, value: "blue"))]),
                                     id: "ff01d1516c",
                                     paused: false,
                                     experimentKeys: [
                                         .init(keyPath: .init(keyPath: ["home"]),
                                               isEntryPoint: true,
-                                              predicate: .init(id: nil, combinator: .and, rules: [.rule(.init(field: "view", ruleOperator: .equal, value: "home"))]),
+                                              predicate: .init(combinator: .and, rules: [.rule(.init(field: "view", ruleOperator: .equal, value: "home"))]),
                                               values: nil,
                                               initializers: false,
                                               subKeys: [
@@ -249,16 +246,14 @@ class ConfigurationDataTest: XCTestCase {
                                                 .init(keyPath: .init(keyPath: ["home", "cta_text"]),
                                                       isEntryPoint: false,
                                                       predicate:
-                                                        .init(id: nil,
-                                                              combinator: .and,
+                                                        .init(combinator: .and,
                                                               rules: [.rule(.init(field: "home", ruleOperator: .contains, value: "none"))]),
                                                       values: true,
                                                       initializers: true,
                                                       subKeys: [
                                                         .init(keyPath: .init(keyPath: ["home", "cta_text", "font"]),
                                                               isEntryPoint: false,
-                                                              predicate: .init(id: nil, combinator: .or,
-                                                                               rules: [.rule(.init(field: "age", ruleOperator: .notEqual, value: "25")),
+                                                              predicate: .init(combinator: .or, rules: [.rule(.init(field: "age", ruleOperator: .notEqual, value: "25")),
                                                                                        .rule(.init(field: "location", ruleOperator: .notEqual, value: "UK"))]),
                                                               values: true,
                                                               initializers: true,

--- a/EvolvSwiftSDK/EvolvSwiftSDKTests/TestingData/allocations.json
+++ b/EvolvSwiftSDK/EvolvSwiftSDKTests/TestingData/allocations.json
@@ -1,5 +1,23 @@
 [
     {
+        "uid": "A",
+        "eid": "1234567890",
+        "cid": "5fa0fd38aae6:1234567890",
+        "genome": {
+            "nochildrennode": {}
+        },
+        "audience_query": {
+            "id": 174,
+            "name": "Empty_Audiences",
+            "combinator": "and",
+            "rules": [
+            ]
+        },
+        "ordinal": 0,
+        "group_id": "a11ce252-92b5-4611-a00c-0e4120369c96",
+        "excluded": false
+    },
+    {
         "uid": "C51EEAFC-724D-47F7-B99A-F3494357F164",
         "eid": "ff01d1516c",
         "cid": "5fa0fd38aae6:47d857cd5e",

--- a/EvolvSwiftSDK/EvolvSwiftSDKTests/TestingData/configuration.json
+++ b/EvolvSwiftSDK/EvolvSwiftSDKTests/TestingData/configuration.json
@@ -8,6 +8,30 @@
     },
     "_experiments": [
         {
+            "_predicate": {
+                "id": "1165",
+                "combinator": "and",
+                "rules": [
+                ]
+            },
+            "nochildrennode": {
+                "_is_entry_point": true,
+                "_predicate": {
+                    "combinator": "and",
+                    "rules": [
+                        {
+                            "field": "noChildren",
+                            "operator": "loose_equal",
+                            "value": "true"
+                        }
+                    ]
+                },
+                "_initializers": true
+            },
+            "id": "1234567890",
+            "_paused": false
+        },
+        {
             "web": {},
             "_predicate": {
                 "id": "1165",

--- a/EvolvSwiftSDK/EvolvSwiftSDKTests/TestingData/configuration.json
+++ b/EvolvSwiftSDK/EvolvSwiftSDKTests/TestingData/configuration.json
@@ -10,12 +10,12 @@
         {
             "web": {},
             "_predicate": {
-                "id": 1165,
+                "id": "1165",
                 "combinator": "and",
                 "rules": [
                     {
                         "field": "location",
-                        "operator": "equal",
+                        "operator": "loose_equal",
                         "value": "UA"
                     },
                     {
@@ -23,7 +23,7 @@
                         "rules": [
                             {
                                 "field": "location",
-                                "operator": "equal",
+                                "operator": "loose_equal",
                                 "value": "UA"
                             },
                             {
@@ -42,7 +42,7 @@
                     "rules": [
                         {
                             "field": "view",
-                            "operator": "equal",
+                            "operator": "loose_equal",
                             "value": "home"
                         }
                     ]
@@ -68,7 +68,7 @@
                     "rules": [
                         {
                             "field": "view",
-                            "operator": "equal",
+                            "operator": "loose_equal",
                             "value": "next"
                         }
                     ]
@@ -87,12 +87,12 @@
         {
             "web": {},
             "_predicate": {
-                "id": 156,
+                "id": "156",
                 "combinator": "and",
                 "rules": [
                     {
                         "field": "signedin",
-                        "operator": "equal",
+                        "operator": "loose_equal",
                         "value": "yes"
                     }
                 ]
@@ -115,12 +115,12 @@
         {
             "web": {},
             "_predicate": {
-                "id": 165,
+                "id": "165",
                 "combinator": "and",
                 "rules": [
                     {
                         "field": "authenticated",
-                        "operator": "equal",
+                        "operator": "loose_equal",
                         "value": "false"
                     },
                     {
@@ -137,17 +137,17 @@
                     "rules": [
                         {
                             "field": "device",
-                            "operator": "equal",
+                            "operator": "loose_equal",
                             "value": "mobile"
                         },
                         {
                             "field": "device",
-                            "operator": "equal",
+                            "operator": "loose_equal",
                             "value": "desktop"
                         },
                         {
                             "field": "platform",
-                            "operator": "equal",
+                            "operator": "loose_equal",
                             "value": "windows"
                         }
                     ]

--- a/EvolvSwiftSDK/EvolvSwiftSDKTests/Utils/Extensions/EvolvSwiftSDK.swift
+++ b/EvolvSwiftSDK/EvolvSwiftSDKTests/Utils/Extensions/EvolvSwiftSDK.swift
@@ -79,8 +79,6 @@ extension EvolvClientOptions: Encodable {
             case evolvDomain
             case participantID
             case environmentId
-            case autoConfirm
-            case analytics
             case blockTransmit
             case bufferEvents
             case remoteContext
@@ -92,8 +90,6 @@ extension EvolvClientOptions: Encodable {
         try container.encode(evolvDomain, forKey: .evolvDomain)
         try container.encode(participantID, forKey: .participantID)
         try container.encode(environmentId, forKey: .environmentId)
-        try container.encode(autoConfirm, forKey: .autoConfirm)
-        try container.encode(analytics, forKey: .analytics)
         try container.encode(blockTransmit, forKey: .blockTransmit)
         try container.encode(remoteContext, forKey: .remoteContext)
         try container.encode(localContext, forKey: .localContext)


### PR DESCRIPTION
Removed id from the decoder -- type had changed so all predicates were null. Id had no use
Also fixed only checking subkeys - variant groups with no children were not in active keys list as a result